### PR TITLE
Fix latent crashes on error and teardown paths

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.4"
+PACKAGE_VERSION="6.4.3.0-patched.5"
 
 BUILT_MODULE_NAME[0]="aic_load_fw"
 BUILT_MODULE_LOCATION[0]="drivers/aic8800/aic_load_fw/"

--- a/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800dc.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800dc.c
@@ -1965,7 +1965,8 @@ int aicwf_plat_patch_load_8800dc(struct rwnx_hw *rwnx_hw){
     int ret = 0;
 
 #ifndef ANDROID_PLATFORM
-        strcat(aic_fw_path, "/aic8800DC");
+        if (strlen(aic_fw_path) + sizeof("/aic8800DC") <= sizeof(aic_fw_path))
+            strcat(aic_fw_path, "/aic8800DC");
 #endif
     if (testmode == 0) {
 #if !defined(CONFIG_FPGA_VERIFICATION)

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1259,6 +1259,10 @@ static int aicwf_usb_alloc_tx_urb(struct aic_usb_dev *usb_dev)
         }
         #ifdef CONFIG_USB_TX_AGGR
         usb_buf->skb = dev_alloc_skb(MAX_USB_AGGR_TXPKT_LEN);
+        if (!usb_buf->skb) {
+            usb_err("could not allocate tx aggr skb\n");
+            goto err;
+        }
         #endif
         #if defined CONFIG_USB_NO_TRANS_DMA_MAP
         // alloc dma buf
@@ -2006,9 +2010,9 @@ static int aicwf_usb_probe(struct usb_interface *intf, const struct usb_device_i
 	ret = aicwf_usb_chipmatch(usb_dev, id->idVendor, id->idProduct);
 	
 	if (ret < 0) {
-        AICWFDBG(LOGERROR, "%s pid:0x%04X vid:0x%04X unsupport\n", 
+        AICWFDBG(LOGERROR, "%s pid:0x%04X vid:0x%04X unsupport\n",
 			__func__, id->idVendor, id->idProduct);
-        goto out_free_bus;
+        goto out_free;
     }
 
     ret = aicwf_parse_usb(usb_dev, intf);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_debugfs.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_debugfs.c
@@ -1235,7 +1235,7 @@ static ssize_t rwnx_dbgfs_regdbg_write(struct file *file,
 
 	struct rwnx_hw *priv = file->private_data;
 	char buf[32];
-	u32 addr,val, oper;
+	u32 addr = 0, val = 0, oper = 0xFFFFFFFF;
 	size_t len = min_t(size_t, count, sizeof(buf) - 1);
     	struct dbg_mem_read_cfm mem_read_cfm;
     	int ret;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -5277,7 +5277,8 @@ struct ieee80211_channel *rwnx_cfg80211_get_channel(struct wiphy *wiphy)
 
     if(found && rwnx_hw->set_chan.center_freq) {
         chan = kzalloc(sizeof(struct ieee80211_channel), GFP_KERNEL);
-        memcpy((u8 *)chan, (u8 *)&rwnx_hw->set_chan, sizeof(struct ieee80211_channel));
+        if (chan)
+            memcpy((u8 *)chan, (u8 *)&rwnx_hw->set_chan, sizeof(struct ieee80211_channel));
     }
 
     return chan;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
@@ -691,14 +691,18 @@ static inline int rwnx_rx_scanu_result_ind(struct rwnx_hw *rwnx_hw,
 
 		//print scan result info start
 		ssid_len = ie[1];
+		if (ssid_len > IEEE80211_MAX_SSID_LEN)
+			ssid_len = IEEE80211_MAX_SSID_LEN;
 		ssid = (char *)kmalloc(sizeof(char)* (ssid_len + 1), GFP_ATOMIC);
-		memset(ssid, 0, ssid_len + 1);
-		memcpy(ssid, &ie[2], ssid_len);
-		freq = ind->center_freq;
-		AICWFDBG(LOGDEBUG, "%s %02x:%02x:%02x:%02x:%02x:%02x ssid:%s freq:%d timestamp:%ld, %d\r\n", __func__, 
-			bss->bssid[0],bss->bssid[1],bss->bssid[2],
-			bss->bssid[3],bss->bssid[4],bss->bssid[5],
-			ssid, freq, (long)mgmt->u.probe_resp.timestamp, ind->rssi);
+		if (ssid && bss) {
+			memset(ssid, 0, ssid_len + 1);
+			memcpy(ssid, &ie[2], ssid_len);
+			freq = ind->center_freq;
+			AICWFDBG(LOGDEBUG, "%s %02x:%02x:%02x:%02x:%02x:%02x ssid:%s freq:%d timestamp:%ld, %d\r\n", __func__,
+				bss->bssid[0],bss->bssid[1],bss->bssid[2],
+				bss->bssid[3],bss->bssid[4],bss->bssid[5],
+				ssid, freq, (long)mgmt->u.probe_resp.timestamp, ind->rssi);
+		}
 		kfree(ssid);
 		ssid = NULL;
 		//print scan result info end
@@ -707,8 +711,16 @@ static inline int rwnx_rx_scanu_result_ind(struct rwnx_hw *rwnx_hw,
 		if(rwnx_hw->wext_scan){
 			
 			scan_re_wext = (struct scanu_result_wext *)vmalloc(sizeof(struct scanu_result_wext));
+			if (!scan_re_wext)
+				return 0;
 			scan_re_wext->ind = (struct scanu_result_ind *)vmalloc(sizeof(struct scanu_result_ind));
 			scan_re_wext->payload = (u32_l *)vmalloc(sizeof(u32_l) * ind->length);
+			if (!scan_re_wext->ind || !scan_re_wext->payload) {
+				vfree(scan_re_wext->ind);
+				vfree(scan_re_wext->payload);
+				vfree(scan_re_wext);
+				return 0;
+			}
 
 			memset(scan_re_wext->ind, 0, sizeof(struct scanu_result_ind));
 			memset(scan_re_wext->payload, 0, ind->length);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
@@ -170,6 +170,7 @@ static inline void limit_chan_bw(u8_l *bw, u16_l primary, u16_l *center1)
 struct rwnx_cmd *rwnx_cmd_malloc(void){
 	struct rwnx_cmd *cmd = NULL;
 	unsigned long flags = 0;
+	bool pending = false;
 
 	spin_lock_irqsave(&cmd_array_lock, flags);
 
@@ -182,16 +183,21 @@ struct rwnx_cmd *rwnx_cmd_malloc(void){
 		}
 	}
 
-	if(cmd_array_index >= RWNX_CMD_HIGH_WATER_SIZE){
-		AICWFDBG(LOGERROR, "%s cmd(%d) was pending...\r\n", __func__, cmd_array_index);
-		mdelay(100);
-	}
+	pending = (cmd_array_index >= RWNX_CMD_HIGH_WATER_SIZE);
 
 	if(!cmd){
 		AICWFDBG(LOGERROR, "%s array is empty...\r\n", __func__);
 	}
 
 	spin_unlock_irqrestore(&cmd_array_lock, flags);
+
+	/* Backpressure when the pool is above high-water. Delay OUTSIDE the lock:
+	   the original mdelay ran under spin_lock_irqsave, stalling every cmd
+	   alloc/free with IRQs disabled for 100ms. */
+	if(pending){
+		AICWFDBG(LOGERROR, "%s cmd pool pending...\r\n", __func__);
+		mdelay(100);
+	}
 
 	return cmd;
 }
@@ -435,6 +441,11 @@ static int rwnx_send_msg(struct rwnx_hw *rwnx_hw, const void *msg_params,
     //nonblock = is_non_blocking_msg(msg->id);
     nonblock = 0;//AIDEN
     cmd = rwnx_cmd_malloc();//kzalloc(sizeof(struct rwnx_cmd), nonblock ? GFP_ATOMIC : GFP_KERNEL);
+    if (!cmd) {
+        AICWFDBG(LOGERROR, "%s: cmd pool exhausted, dropping msg\n", __func__);
+        rwnx_msg_free(rwnx_hw, msg_params);
+        return -ENOMEM;
+    }
     cmd->result  = -EINTR;
     cmd->id      = msg->id;
     cmd->reqid   = reqid;
@@ -512,6 +523,11 @@ static int rwnx_send_msg1(struct rwnx_hw *rwnx_hw, const void *msg_params,
     //nonblock = is_non_blocking_msg(msg->id);
 	nonblock = 0;
     cmd = rwnx_cmd_malloc();//kzalloc(sizeof(struct rwnx_cmd), nonblock ? GFP_ATOMIC : GFP_KERNEL);
+    if (!cmd) {
+        AICWFDBG(LOGERROR, "%s: cmd pool exhausted, dropping msg\n", __func__);
+        rwnx_msg_free(rwnx_hw, msg_params);
+        return -ENOMEM;
+    }
     cmd->result  = -EINTR;
     cmd->id      = msg->id;
     cmd->reqid   = reqid;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_platform.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_platform.c
@@ -279,6 +279,10 @@ static int rwnx_load_firmware(u32 **fw_buf, const char *name, struct device *dev
 	}
 	
 	buffer = vmalloc(size);
+	if (!buffer) {
+		release_firmware(fw);
+		return -1;
+	}
 	memset(buffer, 0, size);
 	memcpy(buffer, dst, size);
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_tx.c
@@ -2093,8 +2093,9 @@ int rwnx_txdatacfm(void *pthis, void *host_id)
     }
 #endif /* CONFIG_RWNX_AMSDUS_TX */
 
+    headroom = sw_txhdr->headroom;
     kmem_cache_free(rwnx_hw->sw_txhdr_cache, sw_txhdr);
-    skb_pull(skb, sw_txhdr->headroom);
+    skb_pull(skb, headroom);
     consume_skb(skb);
 
     return 0;

--- a/drivers/aic8800/aic_load_fw/aicbluetooth.c
+++ b/drivers/aic8800/aic_load_fw/aicbluetooth.c
@@ -237,9 +237,13 @@ static int aic_load_firmware(u32 ** fw_buf, const char *name, struct device *dev
 
 
 	buffer = vmalloc(size);
+	if (!buffer) {
+		release_firmware(fw);
+		return -1;
+	}
 	memset(buffer, 0, size);
 	memcpy(buffer, dst, size);
-	
+
 	*fw_buf = buffer;
 
 	MD5Init(&md5);
@@ -314,7 +318,6 @@ static int aic_load_firmware(u32 ** fw_buf, const char *name, struct device *dev
 
     /* start to read from firmware file */
     buffer = vmalloc(size);
-    memset(buffer, 0, size);
     if(!buffer){
             *fw_buf=NULL;
             __putname(path);
@@ -322,6 +325,7 @@ static int aic_load_firmware(u32 ** fw_buf, const char *name, struct device *dev
             fp=NULL;
             return -1;
     }
+    memset(buffer, 0, size);
 
 
     #if LINUX_VERSION_CODE > KERNEL_VERSION(4, 13, 16)
@@ -350,8 +354,6 @@ static int aic_load_firmware(u32 ** fw_buf, const char *name, struct device *dev
     src = (u32*)buffer;
     //printk("malloc dst\n");
     dst = (u32*)vmalloc(size);
-    memset(dst, 0, size);
-
     if(!dst){
             *fw_buf=NULL;
             __putname(path);
@@ -361,6 +363,7 @@ static int aic_load_firmware(u32 ** fw_buf, const char *name, struct device *dev
             buffer=NULL;
             return -1;
     }
+    memset(dst, 0, size);
 
     for(i=0;i<(size/4);i++){
             dst[i] = src[i];
@@ -1051,7 +1054,18 @@ int rwnx_plat_bin_fw_patch_table_upload_android(struct aic_usb_dev *usbdev, char
 
 	while (p - rawdata < size) {
 		//printk("size = %d  p - rawdata = %d \r\n", size, p - rawdata);
+		/* need a full record header: 16 (name) + 4 (type) + 4 (len) */
+		if ((size - (p - rawdata)) < 24) {
+			printk("patch table: truncated record header\n");
+			ret = -1;
+			goto err;
+		}
+
 		new = (struct aicbt_patch_table *)vmalloc(sizeof(struct aicbt_patch_table));
+		if (!new) {
+			ret = -1;
+			goto err;
+		}
 		memset(new, 0, sizeof(struct aicbt_patch_table));
 		if (head == NULL) {
 			head = new;
@@ -1062,6 +1076,10 @@ int rwnx_plat_bin_fw_patch_table_upload_android(struct aic_usb_dev *usbdev, char
 		}
 
 		cur->name = (char *)vmalloc(sizeof(char) * 16);
+		if (!cur->name) {
+			ret = -1;
+			goto err;
+		}
 		memset(cur->name, 0, sizeof(char) * 16);
 		memcpy(cur->name, p, 16);
 		p += 16;
@@ -1075,7 +1093,18 @@ int rwnx_plat_bin_fw_patch_table_upload_android(struct aic_usb_dev *usbdev, char
 		if((cur->type )  >= 1000 ) {//Temp Workaround
 			cur->len = 0;
 		}else{
+			/* len*8 must fit in the remaining bytes (guards u32 overflow
+			   and reading past the firmware buffer) */
+			if ((u64)cur->len * 8 > (u64)(size - (p - rawdata))) {
+				printk("patch table: bad record len %u\n", cur->len);
+				ret = -1;
+				goto err;
+			}
 			cur->data = (uint32_t *)vmalloc(sizeof(uint8_t) * cur->len * 8);
+			if (!cur->data) {
+				ret = -1;
+				goto err;
+			}
 			memset(cur->data, 0, sizeof(uint8_t) * cur->len * 8);
 			memcpy(cur->data, p, cur->len * 8);
 			p += cur->len * 8;
@@ -1088,7 +1117,7 @@ int rwnx_plat_bin_fw_patch_table_upload_android(struct aic_usb_dev *usbdev, char
 
 	return ret;
 err:
-	//aicbt_patch_table_free(&head);
+	aicbt_patch_table_free(&head);
 
 	if (rawdata){
 		vfree(rawdata);

--- a/drivers/aic8800/aic_load_fw/aicbluetooth_cmds.c
+++ b/drivers/aic8800/aic_load_fw/aicbluetooth_cmds.c
@@ -317,6 +317,11 @@ static int rwnx_send_msg(struct aic_usb_dev *usbdev, const void *msg_params,
 
     nonblock = 0;
     cmd = kzalloc(sizeof(struct rwnx_cmd), nonblock ? GFP_ATOMIC : GFP_KERNEL);
+    if (!cmd) {
+        rwnx_msg_free(msg, msg_params);
+        printk("%s: cmd alloc failed\n", __func__);
+        return -ENOMEM;
+    }
     cmd->result  = -EINTR;
     cmd->id      = msg->id;
     cmd->reqid   = reqid;

--- a/drivers/aic8800/aic_load_fw/aicwf_usb.c
+++ b/drivers/aic8800/aic_load_fw/aicwf_usb.c
@@ -1450,13 +1450,15 @@ static int aicwf_usb_probe(struct usb_interface *intf, const struct usb_device_i
 		rwnx_plat_bin_fw_upload_android(usb_dev, RAM_FW_BLE_SCAN_WAKEUP_ADDR, FW_BLE_SCAN_WAKEUP_NAME);
 		rwnx_send_dbg_mem_write_req(usb_dev, 0x15FF00, 0x53454C42);//magic_num
 		rwnx_send_dbg_mem_write_req(usb_dev, 0x15FF04, ble_scan_wakeup_reboot_time);//reboot time
-		paring_id_num = get_paring_ids(paringid, paring_ids);
-		for(i = 0; i < paring_id_num; i++){
-			printk("paring_ids[%d]:0x%X \r\n", i, paring_ids[i]);
-			rwnx_send_dbg_mem_write_req(usb_dev, 0x15FF08 + (4 * i), paring_ids[i]);
+		if (paring_ids) {
+			paring_id_num = get_paring_ids(paringid, paring_ids);
+			for(i = 0; i < paring_id_num; i++){
+				printk("paring_ids[%d]:0x%X \r\n", i, paring_ids[i]);
+				rwnx_send_dbg_mem_write_req(usb_dev, 0x15FF08 + (4 * i), paring_ids[i]);
+			}
+			kfree(paring_ids);
 		}
 		rwnx_send_dbg_start_app_req(usb_dev, RAM_FW_BLE_SCAN_WAKEUP_ADDR, HOST_START_APP_AUTO);
-		kfree(paring_ids);
 #endif
 		goto out_free_bus;
 	}  else {

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -eu
 
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.4"
+PACKAGE_VERSION="6.4.3.0-patched.5"
 SRC_DIR="/usr/src/${PACKAGE_NAME}-${PACKAGE_VERSION}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.4"
+PACKAGE_VERSION="6.4.3.0-patched.5"
 KVER="$(uname -r)"
 PASS=0
 FAIL=0


### PR DESCRIPTION
Error-path fixes across both modules. Normal path is unchanged.

- rwnx_tx.c: use-after-free in rwnx_txdatacfm, sw_txhdr was read after
  being freed. Cache headroom before the free.
- rwnx_msg_tx.c: NULL-check rwnx_cmd_malloc in rwnx_send_msg and
  rwnx_send_msg1. The pool returns NULL when full and it was used right
  away.
- rwnx_msg_tx.c: move the high-water mdelay(100) out of the spinlock so
  it no longer runs with IRQs disabled.
- aicbluetooth.c: harden the BT patch table parser. Check every vmalloc,
  validate the record length against the bytes left so a bad file cannot
  overflow len*8 or read past the buffer, and free the list on error.
- aicbluetooth.c: move the two memset calls after the NULL check in
  aic_load_firmware, they made the check dead code.
- NULL guards for the remaining allocs: rwnx_msg_rx.c (ssid and wext
  chain, plus an ssid_len clamp), rwnx_platform.c, rwnx_main.c,
  aicwf_usb.c (tx aggr skb and the probe chip-mismatch path),
  aicbluetooth_cmds.c, aic_load_fw/aicwf_usb.c.
- aicwf_compat_8800dc.c: bound the aic_fw_path strcat.
- rwnx_debugfs.c: init the regdbg locals.

Bump to 6.4.3.0-patched.5.
