### PR TITLE
add static analysis (sparse, W=1, cppcheck)

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -42,4 +42,4 @@ jobs:
             echo "### Static analysis"
             echo "- sparse + W=1 warnings: $(grep -c 'warning:' analyze-build.log || true)"
             echo "- cppcheck findings: $(wc -l < cppcheck.log)"
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,0 +1,45 @@
+name: analyze
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Advisory static analysis. It prints and counts warnings but never fails
+# the run, because W=1 on this vendor code is noisy. Use it to spot new
+# warnings, not as a gate.
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    name: static analysis
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential linux-headers-$(uname -r) sparse cppcheck
+
+      - name: sparse + gcc W=1
+        run: |
+          make -C /lib/modules/$(uname -r)/build \
+            M="$GITHUB_WORKSPACE/drivers/aic8800" W=1 C=1 modules \
+            2>&1 | tee analyze-build.log || true
+
+      - name: cppcheck
+        run: |
+          cppcheck --enable=warning,performance,portability \
+            --inline-suppr --quiet --suppress=missingIncludeSystem \
+            drivers/aic8800/aic8800_fdrv drivers/aic8800/aic_load_fw \
+            2> cppcheck.log || true
+          cat cppcheck.log
+
+      - name: summary
+        run: |
+          {
+            echo "### Static analysis"
+            echo "- sparse + W=1 warnings: $(grep -c 'warning:' analyze-build.log || true)"
+            echo "- cppcheck findings: $(wc -l < cppcheck.log)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   scripts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: install.sh + test.sh + uninstall.sh
         run: |
           sudo apt-get update
@@ -38,7 +38,7 @@ jobs:
           - name: latest
             pkgver: ""
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: dkms build
         env:
           PKGVER: ${{ matrix.pkgver }}

--- a/static-analysis.sh
+++ b/static-analysis.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Static analysis for the aic8800dc driver: sparse + gcc W=1 + cppcheck.
+# Advisory only. It prints warnings and never touches the tree.
+#
+# Needs kernel headers for the running kernel, plus sparse and cppcheck:
+#   Debian/Ubuntu: sudo apt-get install sparse cppcheck linux-headers-$(uname -r)
+#   Arch:          sudo pacman -S sparse cppcheck linux-headers
+#
+# Run it from anywhere:  ./static-analysis.sh
+# Drop build artifacts afterwards with:  make -C drivers/aic8800 clean
+
+set -u
+cd "$(dirname "$0")"
+
+KDIR="/lib/modules/$(uname -r)/build"
+BUILD_LOG="/tmp/aic-analyze-build.log"
+CPPCHECK_LOG="/tmp/aic-cppcheck.log"
+
+if [ ! -d "$KDIR" ]; then
+    echo "kernel headers not found at $KDIR" >&2
+    echo "install linux-headers for $(uname -r) and retry" >&2
+    exit 1
+fi
+
+echo "== sparse + gcc W=1 =="
+make -C "$KDIR" M="$(pwd)/drivers/aic8800" W=1 C=1 modules 2>&1 \
+    | tee "$BUILD_LOG" || true
+
+echo
+echo "== cppcheck =="
+if command -v cppcheck >/dev/null 2>&1; then
+    cppcheck --enable=warning,performance,portability \
+        --inline-suppr --quiet --suppress=missingIncludeSystem \
+        drivers/aic8800/aic8800_fdrv drivers/aic8800/aic_load_fw 2>&1 \
+        | tee "$CPPCHECK_LOG" || true
+else
+    echo "cppcheck not installed, skipping" >&2
+    : > "$CPPCHECK_LOG"
+fi
+
+echo
+echo "== summary =="
+echo "sparse + W=1 warnings: $(grep -c 'warning:' "$BUILD_LOG" 2>/dev/null || true)"
+echo "cppcheck findings:     $(wc -l < "$CPPCHECK_LOG" 2>/dev/null || echo 0)"
+echo
+echo "logs: $BUILD_LOG , $CPPCHECK_LOG"


### PR DESCRIPTION
Separate analyze.yml that runs sparse, gcc W=1 and cppcheck on push, PR
and manual dispatch from the Actions tab. Advisory only, it does not fail
the run.

static-analysis.sh runs the same checks locally on a machine with kernel
headers installed.

Also bumps actions/checkout to v7 in build.yml.
