### PR TITLE
add Tenda W311MI v6.0 (2604:0013)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ For Rockchip / Allwinner / Amlogic, set the platform variables in
 ## Build for another kernel without rebooting
 
 ```bash
-sudo dkms build -m aic8800dc -v 6.4.3.0-patched.2 -k <other-version>
+sudo dkms build -m aic8800dc -v 6.4.3.0-patched.6 -k <other-version>
 dkms status
 ```

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.5"
+PACKAGE_VERSION="6.4.3.0-patched.6"
 
 BUILT_MODULE_NAME[0]="aic_load_fw"
 BUILT_MODULE_LOCATION[0]="drivers/aic8800/aic_load_fw/"

--- a/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800dc.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800dc.c
@@ -27,6 +27,7 @@
 #define FW_USERCONFIG_NAME_8800DC_2357    "aic_userconfig_8800dc_2357.txt"
 #define FW_USERCONFIG_NAME_8800DC_2C4E    "aic_userconfig_8800dc_2c4e.txt"
 #define FW_USERCONFIG_NAME_8800DC_3625    "aic_userconfig_8800dc_3625.txt"
+#define FW_USERCONFIG_NAME_8800DC_2604    "aic_userconfig_8800dc_2604.txt"
 
 int rwnx_plat_bin_fw_upload_2(struct rwnx_hw *rwnx_hw, u32 fw_addr,
                                char *filename);
@@ -1994,12 +1995,17 @@ int	rwnx_plat_userconfig_load_8800dc(struct rwnx_hw *rwnx_hw){
     int size;
     u32 *dst=NULL;
     char *filename = FW_USERCONFIG_NAME_8800DC;
-    if (rwnx_hw->usbdev->udev->descriptor.idProduct == 0x0147 && rwnx_hw->usbdev->udev->descriptor.idVendor==0x2357) {
+    u16 vid = le16_to_cpu(rwnx_hw->usbdev->udev->descriptor.idVendor);
+    u16 pid = le16_to_cpu(rwnx_hw->usbdev->udev->descriptor.idProduct);
+
+    if (vid == USB_VENDOR_ID_TP && pid == USB_PRODUCT_ID_TP) {
         filename = FW_USERCONFIG_NAME_8800DC_2357;
-    } else if (rwnx_hw->usbdev->udev->descriptor.idProduct == 0x0114 && rwnx_hw->usbdev->udev->descriptor.idVendor==0x2c4e) {
+    } else if (vid == USB_VENDOR_ID_MERCUSYS && pid == USB_PRODUCT_ID_MERCUSYS) {
         filename = FW_USERCONFIG_NAME_8800DC_2C4E;
-    } else if (rwnx_hw->usbdev->udev->descriptor.idProduct == 0x0110 && rwnx_hw->usbdev->udev->descriptor.idVendor==0x3625) {
+    } else if (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2) {
         filename = FW_USERCONFIG_NAME_8800DC_3625;
+    } else if (vid == USB_VENDOR_ID_TENDA && pid == USB_PRODUCT_ID_TENDA) {
+        filename = FW_USERCONFIG_NAME_8800DC_2604;
     }
 
     AICWFDBG(LOGINFO, "userconfig file path:%s \r\n", filename);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1969,13 +1969,15 @@ static int aicwf_usb_chipmatch(struct aic_usb_dev *usb_dev, u16_l vid, u16_l pid
 		usb_dev->chipid = PRODUCT_ID_AIC8801;
 		AICWFDBG(LOGINFO, "%s USE AIC8801\r\n", __func__);
 		return 0;
-	}else if(pid == USB_PRODUCT_ID_AIC8800DC){
+	}else if(pid == USB_PRODUCT_ID_AIC8800DC ||
+        (vid == USB_VENDOR_ID_TENDA && pid == USB_PRODUCT_ID_TENDA)){
 		usb_dev->chipid = PRODUCT_ID_AIC8800DC;
 		AICWFDBG(LOGINFO, "%s USE AIC8800DC\r\n", __func__);
 		return 0;
-	}else if(pid == USB_PRODUCT_ID_AIC8800DW || pid == USB_PRODUCT_ID_TP
+	}else if(pid == USB_PRODUCT_ID_AIC8800DW
 	 || pid == USB_PRODUCT_ID_AIC8800FC ||
-        (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2)
+        (vid == USB_VENDOR_ID_TP && pid == USB_PRODUCT_ID_TP)
+        || (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2)
         || (vid == USB_VENDOR_ID_MERCUSYS && pid == USB_PRODUCT_ID_MERCUSYS)){
         usb_dev->chipid = PRODUCT_ID_AIC8800DW;
 		AICWFDBG(LOGINFO, "%s USE AIC8800DW\r\n", __func__);
@@ -2010,7 +2012,7 @@ static int aicwf_usb_probe(struct usb_interface *intf, const struct usb_device_i
 	ret = aicwf_usb_chipmatch(usb_dev, id->idVendor, id->idProduct);
 	
 	if (ret < 0) {
-        AICWFDBG(LOGERROR, "%s pid:0x%04X vid:0x%04X unsupport\n",
+        AICWFDBG(LOGERROR, "%s vid:0x%04X pid:0x%04X unsupport\n",
 			__func__, id->idVendor, id->idProduct);
         goto out_free;
     }
@@ -2210,7 +2212,9 @@ static struct usb_device_id aicwf_usb_id_table[] = {
     {USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800DC, 0xff, 0xff, 0xff)},
     {USB_DEVICE(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800DW)},
     {USB_DEVICE(USB_VENDOR_ID_AIC_V2, USB_PRODUCT_ID_AIC8800FC)},
-    //{USB_DEVICE(USB_VENDOR_ID_TENDA, USB_PRODUCT_ID_TENDA)},
+    {USB_DEVICE(USB_VENDOR_ID_TENDA, USB_PRODUCT_ID_TENDA)},
+    /* Tenda U2 (2604:0014) is untested: it has no entry in aicwf_usb_chipmatch()
+       and no RF calibration file, so binding it would only fail probe. */
     //{USB_DEVICE(USB_VENDOR_ID_TENDA, USB_PRODUCT_ID_TENDA_U2)},
     {USB_DEVICE(USB_VENDOR_ID_TP, USB_PRODUCT_ID_TP)},
     {USB_DEVICE(USB_VENDOR_ID_TP2, USB_PRODUCT_ID_TP2)},

--- a/fw/aic8800DC/aic_userconfig_8800dc_2604.txt
+++ b/fw/aic8800DC/aic_userconfig_8800dc_2604.txt
@@ -1,0 +1,62 @@
+# AIC USERCONFIG 2022/0803/1707
+# Tenda (VID 2604) - W311MI v6.0, USB 2604:0013
+# TX power levels taken from the vendor's aic_userconfig_8800dw_w311.txt.
+# The loss keys use this driver's schema (loss_enable/loss_value); the vendor
+# file's loss_*_2g4 / loss_*_5g variants are not understood by
+# rwnx_plat_nvram_set_value() and would be silently ignored.
+
+# txpwr_lvl
+enable=1
+lvl_11b_11ag_1m_2g4=21
+lvl_11b_11ag_2m_2g4=21
+lvl_11b_11ag_5m5_2g4=21
+lvl_11b_11ag_11m_2g4=21
+lvl_11b_11ag_6m_2g4=21
+lvl_11b_11ag_9m_2g4=21
+lvl_11b_11ag_12m_2g4=21
+lvl_11b_11ag_18m_2g4=21
+lvl_11b_11ag_24m_2g4=21
+lvl_11b_11ag_36m_2g4=20
+lvl_11b_11ag_48m_2g4=19
+lvl_11b_11ag_54m_2g4=19
+lvl_11n_11ac_mcs0_2g4=21
+lvl_11n_11ac_mcs1_2g4=21
+lvl_11n_11ac_mcs2_2g4=21
+lvl_11n_11ac_mcs3_2g4=21
+lvl_11n_11ac_mcs4_2g4=21
+lvl_11n_11ac_mcs5_2g4=20
+lvl_11n_11ac_mcs6_2g4=19
+lvl_11n_11ac_mcs7_2g4=19
+lvl_11n_11ac_mcs8_2g4=18
+lvl_11n_11ac_mcs9_2g4=18
+lvl_11ax_mcs0_2g4=21
+lvl_11ax_mcs1_2g4=21
+lvl_11ax_mcs2_2g4=21
+lvl_11ax_mcs3_2g4=21
+lvl_11ax_mcs4_2g4=21
+lvl_11ax_mcs5_2g4=20
+lvl_11ax_mcs6_2g4=19
+lvl_11ax_mcs7_2g4=19
+lvl_11ax_mcs8_2g4=18
+lvl_11ax_mcs9_2g4=18
+lvl_11ax_mcs10_2g4=17
+lvl_11ax_mcs11_2g4=17
+
+# txpwr_loss
+loss_enable=0
+loss_value=2
+
+# txpwr_ofst
+ofst_enable=0
+ofst_chan_1_4=0
+ofst_chan_5_9=0
+ofst_chan_10_13=0
+ofst_chan_36_64=0
+ofst_chan_100_120=0
+ofst_chan_122_140=0
+ofst_chan_142_165=0
+
+# xtal cap
+xtal_enable=0
+xtal_cap=24
+xtal_cap_fine=31

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -eu
 
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.5"
+PACKAGE_VERSION="6.4.3.0-patched.6"
 SRC_DIR="/usr/src/${PACKAGE_NAME}-${PACKAGE_VERSION}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.5"
+PACKAGE_VERSION="6.4.3.0-patched.6"
 KVER="$(uname -r)"
 PASS=0
 FAIL=0


### PR DESCRIPTION
Supersedes #15 by @RotRot-pi, who found the device and confirmed it works.

## What this adds

Registers Tenda `2604:0013` (W311MI v6.0, AIC8800DC silicon) in `aicwf_usb_id_table[]` and maps it to `PRODUCT_ID_AIC8800DC` in `aicwf_usb_chipmatch()`.

## Why it differs from #15

**VID+PID instead of a bare PID check.** #15 added `pid == USB_PRODUCT_ID_TENDA` to the DC branch. OEM product IDs are low numbers assigned per vendor (`0x0013` Tenda, `0x0110` TP2, `0x0114` Mercusys, `0x0147` TP) and collide easily; only AIC's own PIDs (`0x8801`, `0x88dc`, ...) are unique enough to match bare. The TP2 and Mercusys clauses were already written as VID+PID pairs for that reason, so the Tenda one now matches that convention.

While in there I gave the pre-existing `pid == USB_PRODUCT_ID_TP` the same guard. It is the last bare OEM match left, same bug class, and provably safe to narrow since `2357:0147` is the only entry in the table using that PID.

**U2 stays commented out.** #15 also uncommented `USB_PRODUCT_ID_TENDA_U2` (`2604:0014`), which has no `chipmatch` entry and no calibration file. The driver would claim the device and then fail probe, which is worse than not binding it at all. Left commented with a note explaining what it needs.

## RF calibration

The bigger find. Without a per-vendor file the stick falls back to `aic_userconfig_8800dc.txt`, which carries AIC's conservative reference values. AIC ships a real profile for this model as `aic_userconfig_8800dw_w311.txt` (W311 = W311MI), and every one of the 34 rate levels is higher:

| rate group | generic | W311 | delta |
| --- | --- | --- | --- |
| 11b/11ag 1-18M | 19 | 21 | +2 |
| 11b/11ag 24M | 18 | 21 | +3 |
| 11b/11ag 48/54M | 16 | 19 | +3 |
| 11n mcs0-4 | 18 | 21 | +3 |
| 11n mcs7 | 17 | 19 | +2 |
| 11ax mcs0-4 | 17 | 21 | +4 |
| 11ax mcs10/11 | 15 | 17 | +2 |

Added as `fw/aic8800DC/aic_userconfig_8800dc_2604.txt`. The loss keys are written in this driver's schema (`loss_enable` / `loss_value`) because `rwnx_plat_nvram_set_value()` does not understand the newer `loss_*_2g4` / `loss_*_5g` variants in the vendor file and would silently ignore them. `ofst_*` and `xtal_*` are identical between the two files, so the power table is the entire delta.

Worth noting the profile is a near-copy of the existing TP-Link `_2357.txt`, differing on one rate (`lvl_11n_11ac_mcs5_2g4`, 20 vs 21). AIC evidently hands OEMs the same tuning. It is still the right file to use since it is the one shipped under this model's name.

## Other changes

The userconfig if-chain in `rwnx_plat_userconfig_load_8800dc()` was comparing hardcoded hex (`idProduct == 0x0147 && idVendor == 0x2357`) while `chipmatch` uses named macros for the same devices. Converted it to the macros and hoisted `vid`/`pid` locals so the two dispatch sites read the same way. Also wrapped the descriptor reads in `le16_to_cpu()`, which is what they should have been.

Fixed a swapped pair of log arguments in `aicwf_usb_probe()`: the format string said `pid:...vid:...` while the arguments were passed vendor-first.

## Testing

Built by CI against 6.12 LTS, 7.1 stable and latest. I do not have this hardware, so the on-device confirmation is @RotRot-pi's from #15. A re-test against this branch would be welcome, particularly to see the new userconfig path get picked up:

```
dmesg | grep -i "userconfig file path"
```

should now report `aic_userconfig_8800dc_2604.txt` rather than the generic file.