### PR TITLE
follow the kernel 7.2 remain_on_channel signature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,3 +60,28 @@ jobs:
             dkms add   -m "$PACKAGE_NAME" -v "$PACKAGE_VERSION"
             dkms build -m "$PACKAGE_NAME" -v "$PACKAGE_VERSION" -k "$kver"
           '
+
+  # Early warning only: mainline -rc breaks us weeks before Arch ships the final
+  # release, but an -rc can also be broken on its own, so this must never gate a
+  # merge. Fedora Rawhide is used because it packages mainline -rc kernel-devel,
+  # which avoids compiling a kernel just to get headers.
+  rc:
+    runs-on: ubuntu-latest
+    name: mainline rc
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: dkms build
+        run: |
+          docker run --rm -v "$PWD:/src:ro" fedora:rawhide bash -c '
+            set -e
+            dnf -y install kernel-devel dkms gcc make bc kmod
+            kver=$(ls -1 /usr/src/kernels | head -1)
+            echo "building against $kver"
+            . /src/dkms.conf
+            mkdir -p "/usr/src/$PACKAGE_NAME-$PACKAGE_VERSION"
+            cp -a /src/. "/usr/src/$PACKAGE_NAME-$PACKAGE_VERSION/"
+            dkms add   -m "$PACKAGE_NAME" -v "$PACKAGE_VERSION"
+            dkms build -m "$PACKAGE_NAME" -v "$PACKAGE_VERSION" -k "$kver" \
+              --kernelsourcedir "/usr/src/kernels/$kver"
+          '

--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ For Rockchip / Allwinner / Amlogic, set the platform variables in
 ## Build for another kernel without rebooting
 
 ```bash
-sudo dkms build -m aic8800dc -v 6.4.3.0-patched.7 -k <other-version>
+sudo dkms build -m aic8800dc -v 6.4.3.0-patched.8 -k <other-version>
 dkms status
 ```

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.7"
+PACKAGE_VERSION="6.4.3.0-patched.8"
 
 BUILT_MODULE_NAME[0]="aic_load_fw"
 BUILT_MODULE_LOCATION[0]="drivers/aic8800/aic_load_fw/"

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -5001,7 +5001,14 @@ rwnx_cfg80211_remain_on_channel(struct wiphy *wiphy,
                             #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
                                 enum nl80211_channel_type channel_type,
                             #endif
-                                unsigned int duration, u64 *cookie)
+                                unsigned int duration, u64 *cookie
+                            #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
+                                /* Always NULL here: cfg80211 refuses an address
+                                 * filter unless the driver advertises
+                                 * NL80211_EXT_FEATURE_ROC_ADDR_FILTER. */
+                                , const u8 *rx_addr
+                            #endif
+                                )
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
@@ -5389,7 +5396,10 @@ static int rwnx_cfg80211_mgmt_tx(struct wiphy *wiphy, struct wireless_dev *wdev,
 		AICWFDBG(LOGINFO, "mgmt rx remain on chan\n");
 
         /* Start a ROC procedure for 30ms */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+        error = rwnx_cfg80211_remain_on_channel(wiphy, wdev, channel,
+                                                30, &cookie, NULL);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
         error = rwnx_cfg80211_remain_on_channel(wiphy, wdev, channel,
                                                 30, &cookie);
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0))

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -eu
 
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.7"
+PACKAGE_VERSION="6.4.3.0-patched.8"
 SRC_DIR="/usr/src/${PACKAGE_NAME}-${PACKAGE_VERSION}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.7"
+PACKAGE_VERSION="6.4.3.0-patched.8"
 KVER="$(uname -r)"
 PASS=0
 FAIL=0


### PR DESCRIPTION
Fixes #18.

Kernel 7.2 gave remain_on_channel a sixth parameter, an rx_addr address
filter (torvalds/linux@4dbd1829045e). Absent in v7.1, in mainline since
the 7.2 merge window, so the module stops building once 7.2 ships.

Ignoring the address is safe rather than just convenient. cfg80211 fills
it in only for drivers advertising NL80211_EXT_FEATURE_ROC_ADDR_FILTER and
refuses the request from anyone else, so it always reaches us NULL. That
covers the question left open in the issue about a real RoC request.

The rest of the 7.2 wireless churn looks clear for us. ready_on_channel
and remain_on_channel_expired are untouched, remain_on_channel is the only
altered member of cfg80211_ops among the 36 ops we implement, start_pd and
stop_pd are new and additive, and the 5/10 MHz removal hits nothing we
reference.

Second commit exists because this arrived as a bug report five weeks after
it landed upstream. The matrix only builds released kernels, so the first
warning comes the week Arch ships the final tag. Rawhide packages -rc
kernel-devel, which makes the check cheap. It stays non-blocking, latest
remains the gate on what people actually run.