### PR TITLE
classify Mercusys MA14N (2c4e:0114) as AIC8800DC, not AIC8800DW

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1803,8 +1803,16 @@ static int aicwf_parse_usb(struct aic_usb_dev *usb_dev, struct usb_interface *in
 	   AICWFDBG(LOGERROR, "Number of interfaces: %d not supported\n",
             usb->actconfig->desc.bNumInterfaces);
 		if(usb_dev->chipid == PRODUCT_ID_AIC8800DC){
-			AICWFDBG(LOGERROR, "AIC8800DC change to AIC8800DW\n");
-			usb_dev->chipid = PRODUCT_ID_AIC8800DW;
+			/* Mercusys MA14N is a true AIC8800DC with a single WLAN
+			   interface; remapping it to DW loads the wrong firmware
+			   config (54 KB/s, ~40% packet loss, cfg80211 deadlock) */
+			if (le16_to_cpu(usb->descriptor.idVendor) == USB_VENDOR_ID_MERCUSYS &&
+			    le16_to_cpu(usb->descriptor.idProduct) == USB_PRODUCT_ID_MERCUSYS) {
+				AICWFDBG(LOGERROR, "Mercusys AIC8800DC single interface, keep DC\n");
+			} else {
+				AICWFDBG(LOGERROR, "AIC8800DC change to AIC8800DW\n");
+				usb_dev->chipid = PRODUCT_ID_AIC8800DW;
+			}
         }else if (usb_dev->chipid == PRODUCT_ID_AIC8800DW) {
             printk("8800dw\n");
 		}
@@ -1970,15 +1978,17 @@ static int aicwf_usb_chipmatch(struct aic_usb_dev *usb_dev, u16_l vid, u16_l pid
 		AICWFDBG(LOGINFO, "%s USE AIC8801\r\n", __func__);
 		return 0;
 	}else if(pid == USB_PRODUCT_ID_AIC8800DC ||
-        (vid == USB_VENDOR_ID_TENDA && pid == USB_PRODUCT_ID_TENDA)){
+        (vid == USB_VENDOR_ID_TENDA && pid == USB_PRODUCT_ID_TENDA)
+        /* Mercusys MA14N carries an AIC8800DC (USB product string
+           "AIC8800DC"); classifying it as DW loads the wrong fw config */
+        || (vid == USB_VENDOR_ID_MERCUSYS && pid == USB_PRODUCT_ID_MERCUSYS)){
 		usb_dev->chipid = PRODUCT_ID_AIC8800DC;
 		AICWFDBG(LOGINFO, "%s USE AIC8800DC\r\n", __func__);
 		return 0;
 	}else if(pid == USB_PRODUCT_ID_AIC8800DW
 	 || pid == USB_PRODUCT_ID_AIC8800FC ||
         (vid == USB_VENDOR_ID_TP && pid == USB_PRODUCT_ID_TP)
-        || (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2)
-        || (vid == USB_VENDOR_ID_MERCUSYS && pid == USB_PRODUCT_ID_MERCUSYS)){
+        || (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2)){
         usb_dev->chipid = PRODUCT_ID_AIC8800DW;
 		AICWFDBG(LOGINFO, "%s USE AIC8800DW\r\n", __func__);
         return 0;

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1800,21 +1800,21 @@ static int aicwf_parse_usb(struct aic_usb_dev *usb_dev, struct usb_interface *in
 #else
     if (usb->actconfig->desc.bNumInterfaces != 1) {
 #endif
-	   AICWFDBG(LOGERROR, "Number of interfaces: %d not supported\n",
-            usb->actconfig->desc.bNumInterfaces);
-		if(usb_dev->chipid == PRODUCT_ID_AIC8800DC){
-			/* Mercusys MA14N is a true AIC8800DC with a single WLAN
-			   interface; remapping it to DW loads the wrong firmware
-			   config (54 KB/s, ~40% packet loss, cfg80211 deadlock) */
-			if (le16_to_cpu(usb->descriptor.idVendor) == USB_VENDOR_ID_MERCUSYS &&
-			    le16_to_cpu(usb->descriptor.idProduct) == USB_PRODUCT_ID_MERCUSYS) {
-				AICWFDBG(LOGERROR, "Mercusys AIC8800DC single interface, keep DC\n");
-			} else {
+		/* The MA14N has no Bluetooth, so it shows one interface where a
+		   BT build expects three. Normal for this stick, and the DC
+		   chipid from its VID/PID has to survive. */
+		if (le16_to_cpu(usb->descriptor.idVendor) == USB_VENDOR_ID_MERCUSYS &&
+		    le16_to_cpu(usb->descriptor.idProduct) == USB_PRODUCT_ID_MERCUSYS) {
+			AICWFDBG(LOGINFO, "Mercusys MA14N: single interface, keeping AIC8800DC\n");
+		} else {
+			AICWFDBG(LOGERROR, "Number of interfaces: %d not supported\n",
+				usb->actconfig->desc.bNumInterfaces);
+			if(usb_dev->chipid == PRODUCT_ID_AIC8800DC){
 				AICWFDBG(LOGERROR, "AIC8800DC change to AIC8800DW\n");
 				usb_dev->chipid = PRODUCT_ID_AIC8800DW;
+			}else if (usb_dev->chipid == PRODUCT_ID_AIC8800DW) {
+				printk("8800dw\n");
 			}
-        }else if (usb_dev->chipid == PRODUCT_ID_AIC8800DW) {
-            printk("8800dw\n");
 		}
     }
 
@@ -1979,8 +1979,7 @@ static int aicwf_usb_chipmatch(struct aic_usb_dev *usb_dev, u16_l vid, u16_l pid
 		return 0;
 	}else if(pid == USB_PRODUCT_ID_AIC8800DC ||
         (vid == USB_VENDOR_ID_TENDA && pid == USB_PRODUCT_ID_TENDA)
-        /* Mercusys MA14N carries an AIC8800DC (USB product string
-           "AIC8800DC"); classifying it as DW loads the wrong fw config */
+        /* MA14N reports itself as AIC8800DC; it sat in the DW branch below */
         || (vid == USB_VENDOR_ID_MERCUSYS && pid == USB_PRODUCT_ID_MERCUSYS)){
 		usb_dev->chipid = PRODUCT_ID_AIC8800DC;
 		AICWFDBG(LOGINFO, "%s USE AIC8800DC\r\n", __func__);


### PR DESCRIPTION
Closes #9

In #9 you confirmed the Mercusys MA14N (2c4e:0114) is a true AIC8800DC — its USB product string reads "AIC8800DC" and a DC userconfig path for it already exists (`aic_userconfig_8800dc_2c4e.txt`) — and asked for a PR moving its VID/PID clause from the DW branch to the DC branch of `aicwf_usb_chipmatch()`. That PR never arrived, so here it is.

One addition on top of what was discussed in the issue: the `chipmatch()` move alone is not enough on `CONFIG_USB_BT` builds. The MA14N has no Bluetooth and reports `bNumInterfaces=1`, while `CONFIG_USB_BT` builds expect 3, so the interface-count check in `aicwf_parse_usb()` re-remapped the chipid DC->DW right after `chipmatch()` had set it correctly. The second hunk keeps DC for this VID/PID in that path; every other device keeps the original remap behaviour.

Measured impact of the wrong DW classification on an MA14N: ~54 KB/s throughput, ~40% packet loss, and a cfg80211 mutex deadlock (kworker + NetworkManager + wpa_supplicant blocked >122 s) that freezes the whole machine.

Tested on kernel 6.8.0-136-generic (Ubuntu 24.04): dmesg shows "USE AIC8800DC" and "Mercusys AIC8800DC single interface, keep DC", 0% packet loss, 3.4 MB/s sustained download, no deadlock, stable across reboots.