### PR TITLE
fix static analysis findings, pin workflow token to read-only

### DIFF
--- a/.github/analysis-baseline
+++ b/.github/analysis-baseline
@@ -2,5 +2,5 @@
 # the point is that a patch may not make it noisier. Lower these when you fix
 # warnings. Re-baseline if the runner image or tool versions change.
 
-SPARSE_MAX=191
-CPPCHECK_MAX=40
+SPARSE_MAX=111
+CPPCHECK_MAX=37

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Ratchet, not a clean-tree gate: W=1 on this vendor code is far too noisy to
 # demand zero warnings, so this only fails when a patch pushes a count past the
 # ceiling in .github/analysis-baseline.

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -12,6 +12,9 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   dkms:
     runs-on: ubuntu-latest

--- a/.github/workflows/kernel-6.12-lts.yml
+++ b/.github/workflows/kernel-6.12-lts.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/build-kernel.yml

--- a/.github/workflows/kernel-7.1.yml
+++ b/.github/workflows/kernel-7.1.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/build-kernel.yml

--- a/.github/workflows/kernel-latest.yml
+++ b/.github/workflows/kernel-latest.yml
@@ -10,6 +10,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/build-kernel.yml

--- a/.github/workflows/kernel-mainline-rc.yml
+++ b/.github/workflows/kernel-mainline-rc.yml
@@ -13,6 +13,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dkms:
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   install-test-uninstall:
     runs-on: ubuntu-latest

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -902,7 +902,6 @@ static void aicwf_usb_tx_process(struct aic_usb_dev *usb_dev)
 {
     struct aicwf_usb_buf *usb_buf;
     int ret = 0;
-    u8* data = NULL;
 
 #ifdef CONFIG_USB_TX_AGGR
     if (!aicwf_is_framequeue_empty(&usb_dev->tx_priv->txq)) {
@@ -925,7 +924,6 @@ static void aicwf_usb_tx_process(struct aic_usb_dev *usb_dev)
             usb_err("can not get usb_buf from tx_post_list!\n");
             return;
         }
-        data = usb_buf->skb->data;
 
         ret = usb_submit_urb(usb_buf->urb, GFP_ATOMIC);
         if (ret) {
@@ -1314,12 +1312,9 @@ err:
 
 static void aicwf_usb_state_change(struct aic_usb_dev *usb_dev, int state)
 {
-    int old_state;
-
     if (usb_dev->state == state)
         return;
 
-    old_state = usb_dev->state;
     usb_dev->state = state;
 
     if (state == USB_DOWN_ST) {

--- a/drivers/aic8800/aic8800_fdrv/ipc_host.c
+++ b/drivers/aic8800/aic8800_fdrv/ipc_host.c
@@ -239,10 +239,10 @@ static void ipc_host_tx_cfm_handler(struct ipc_host_env_tag *env,
         void *host_id = env->tx_host_id[queue_idx][user_pos][used_idx_mod];
 
         // Reset the host id in the array
-        env->tx_host_id[queue_idx][user_pos][used_idx_mod] = 0;
+        env->tx_host_id[queue_idx][user_pos][used_idx_mod] = NULL;
 
         // call the external function to indicate that a TX packet is freed
-        if (host_id == 0)
+        if (host_id == NULL)
         {
             // No more confirmations, so put back the used index at its initial value
             env->txdesc_used_idx[queue_idx][user_pos] = used_idx;
@@ -302,10 +302,10 @@ void *ipc_host_tx_flush(struct ipc_host_env_tag *env, const int queue_idx, const
     void *host_id = env->tx_host_id[queue_idx][user_pos][used_idx & nx_txdesc_cnt_msk[queue_idx]];
 
     // call the external function to indicate that a TX packet is freed
-    if (host_id != 0)
+    if (host_id != NULL)
     {
         // Reset the host id in the array
-        env->tx_host_id[queue_idx][user_pos][used_idx & nx_txdesc_cnt_msk[queue_idx]] = 0;
+        env->tx_host_id[queue_idx][user_pos][used_idx & nx_txdesc_cnt_msk[queue_idx]] = NULL;
 
         // Increment the used index
         env->txdesc_used_idx[queue_idx][user_pos]++;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_cmds.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_cmds.c
@@ -62,8 +62,6 @@ static void cmd_complete(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd)
 
 int cmd_mgr_queue_force_defer(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd)
 {
-    bool defer_push = false;
-
     RWNX_DBG(RWNX_FN_ENTRY_STR);
 #ifdef CREATE_TRACE_POINTS
     trace_msg_send(cmd->id);
@@ -90,7 +88,6 @@ int cmd_mgr_queue_force_defer(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd
     #endif
 
     cmd->flags |= RWNX_CMD_FLAG_WAIT_PUSH;
-    defer_push = true;
 
     if (cmd->flags & RWNX_CMD_FLAG_REQ_CFM)
         cmd->flags |= RWNX_CMD_FLAG_WAIT_CFM;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_debugfs.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_debugfs.c
@@ -1238,7 +1238,6 @@ static ssize_t rwnx_dbgfs_regdbg_write(struct file *file,
 	u32 addr = 0, val = 0, oper = 0xFFFFFFFF;
 	size_t len = min_t(size_t, count, sizeof(buf) - 1);
     	struct dbg_mem_read_cfm mem_read_cfm;
-    	int ret;
 
 	if (copy_from_user(buf, user_buf, len))
 		return -EFAULT;
@@ -1249,7 +1248,7 @@ static ssize_t rwnx_dbgfs_regdbg_write(struct file *file,
 		printk("addr=%x, val=%x,oper=%d\n", addr, val, oper);
 
     	if(oper== 0) {
-		ret = rwnx_send_dbg_mem_read_req(priv, addr, &mem_read_cfm);
+		rwnx_send_dbg_mem_read_req(priv, addr, &mem_read_cfm);
         	printk("[0x%x] = [0x%x]\n", mem_read_cfm.memaddr, mem_read_cfm.memdata);
     	}
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2613,7 +2613,7 @@ static struct net_device_stats *rwnx_get_stats(struct net_device *dev)
  *	Called to decide which queue to when device supports multiple
  *	transmit queues.
  */
-u16 rwnx_select_queue(struct net_device *dev, struct sk_buff *skb,
+static u16 rwnx_select_queue(struct net_device *dev, struct sk_buff *skb,
                       struct net_device *sb_dev)
 {
     struct rwnx_vif *rwnx_vif = netdev_priv(dev);
@@ -4690,7 +4690,6 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_vif *rwnx_vif = netdev_priv(dev);
-    struct rwnx_sta *sta;
 
     RWNX_DBG(RWNX_FN_ENTRY_STR);
 
@@ -4717,7 +4716,6 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
     }
 
     /* delete BC/MC STA */
-    sta = &rwnx_hw->sta_table[rwnx_vif->ap.bcmc_index];
     rwnx_txq_vif_deinit(rwnx_hw, rwnx_vif);
     rwnx_del_bcn(&rwnx_vif->ap.bcn);
     rwnx_del_csa(rwnx_vif);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
@@ -32,7 +32,7 @@
 
 static int rwnx_freq_to_idx(struct rwnx_hw *rwnx_hw, int freq)
 {
-    struct ieee80211_supported_band *sband;
+    struct ieee80211_supported_band *sband = NULL;
     int band, ch, idx = 0;
 
     for (band = NL80211_BAND_2GHZ; band < NUM_NL80211_BANDS; band++) {
@@ -165,9 +165,9 @@ static inline int rwnx_rx_tdls_chan_switch_ind(struct rwnx_hw *rwnx_hw,
 #ifdef CONFIG_RWNX_FULLMAC
     // Enable traffic on OFF channel queue
     rwnx_txq_offchan_start(rwnx_hw);
+#endif
 
     return 0;
-#endif
 }
 
 static inline int rwnx_rx_tdls_chan_switch_base_ind(struct rwnx_hw *rwnx_hw,
@@ -186,8 +186,9 @@ static inline int rwnx_rx_tdls_chan_switch_base_ind(struct rwnx_hw *rwnx_hw,
             rwnx_txq_tdls_sta_stop(rwnx_vif, RWNX_TXQ_STOP_CHAN, rwnx_hw);
         }
     }
-    return 0;
 #endif
+
+    return 0;
 }
 
 static inline int rwnx_rx_tdls_peer_ps_ind(struct rwnx_hw *rwnx_hw,
@@ -206,9 +207,9 @@ static inline int rwnx_rx_tdls_peer_ps_ind(struct rwnx_hw *rwnx_hw,
             rwnx_ps_bh_enable(rwnx_hw, rwnx_vif->sta.tdls_sta, ps_on);
         }
     }
+#endif
 
     return 0;
-#endif
 }
 
 static inline int rwnx_rx_remain_on_channel_exp_ind(struct rwnx_hw *rwnx_hw,
@@ -702,7 +703,7 @@ static inline int rwnx_rx_scanu_result_ind(struct rwnx_hw *rwnx_hw,
 			AICWFDBG(LOGDEBUG, "%s %02x:%02x:%02x:%02x:%02x:%02x ssid:%s freq:%d timestamp:%ld, %d\r\n", __func__,
 				bss->bssid[0],bss->bssid[1],bss->bssid[2],
 				bss->bssid[3],bss->bssid[4],bss->bssid[5],
-				ssid, freq, (long)mgmt->u.probe_resp.timestamp, ind->rssi);
+				ssid, freq, (long)le64_to_cpu(mgmt->u.probe_resp.timestamp), ind->rssi);
 		}
 		kfree(ssid);
 		ssid = NULL;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
@@ -1791,10 +1791,10 @@ int rwnx_send_me_config_req(struct rwnx_hw *rwnx_hw)
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0) || defined(CONFIG_VHT_FOR_OLD_KERNEL)
     if(req->vht_supp) {
     	req->vht_cap.vht_capa_info = cpu_to_le32(vht_cap->cap);
-    	req->vht_cap.rx_highest = cpu_to_le16(vht_cap->vht_mcs.rx_highest);
-    	req->vht_cap.rx_mcs_map = cpu_to_le16(vht_cap->vht_mcs.rx_mcs_map);
-    	req->vht_cap.tx_highest = cpu_to_le16(vht_cap->vht_mcs.tx_highest);
-    	req->vht_cap.tx_mcs_map = cpu_to_le16(vht_cap->vht_mcs.tx_mcs_map);
+    	req->vht_cap.rx_highest = (__force u16_l)vht_cap->vht_mcs.rx_highest;
+    	req->vht_cap.rx_mcs_map = (__force u16_l)vht_cap->vht_mcs.rx_mcs_map;
+    	req->vht_cap.tx_highest = (__force u16_l)vht_cap->vht_mcs.tx_highest;
+    	req->vht_cap.tx_mcs_map = (__force u16_l)vht_cap->vht_mcs.tx_mcs_map;
     }
     #endif
 
@@ -1816,12 +1816,12 @@ int rwnx_send_me_config_req(struct rwnx_hw *rwnx_hw)
 		for (i = 0; i < ARRAY_SIZE(he_cap->he_cap_elem.phy_cap_info); i++) {
 			req->he_cap.phy_cap_info[i] = he_cap->he_cap_elem.phy_cap_info[i];
 		}
-		req->he_cap.mcs_supp.rx_mcs_80 = cpu_to_le16(he_cap->he_mcs_nss_supp.rx_mcs_80);
-		req->he_cap.mcs_supp.tx_mcs_80 = cpu_to_le16(he_cap->he_mcs_nss_supp.tx_mcs_80);
-		req->he_cap.mcs_supp.rx_mcs_160 = cpu_to_le16(he_cap->he_mcs_nss_supp.rx_mcs_160);
-		req->he_cap.mcs_supp.tx_mcs_160 = cpu_to_le16(he_cap->he_mcs_nss_supp.tx_mcs_160);
-		req->he_cap.mcs_supp.rx_mcs_80p80 = cpu_to_le16(he_cap->he_mcs_nss_supp.rx_mcs_80p80);
-		req->he_cap.mcs_supp.tx_mcs_80p80 = cpu_to_le16(he_cap->he_mcs_nss_supp.tx_mcs_80p80);
+		req->he_cap.mcs_supp.rx_mcs_80 = (__force u16_l)he_cap->he_mcs_nss_supp.rx_mcs_80;
+		req->he_cap.mcs_supp.tx_mcs_80 = (__force u16_l)he_cap->he_mcs_nss_supp.tx_mcs_80;
+		req->he_cap.mcs_supp.rx_mcs_160 = (__force u16_l)he_cap->he_mcs_nss_supp.rx_mcs_160;
+		req->he_cap.mcs_supp.tx_mcs_160 = (__force u16_l)he_cap->he_mcs_nss_supp.tx_mcs_160;
+		req->he_cap.mcs_supp.rx_mcs_80p80 = (__force u16_l)he_cap->he_mcs_nss_supp.rx_mcs_80p80;
+		req->he_cap.mcs_supp.tx_mcs_80p80 = (__force u16_l)he_cap->he_mcs_nss_supp.tx_mcs_80p80;
 		for (i = 0; i < MAC_HE_PPE_THRES_MAX_LEN; i++) {
 			req->he_cap.ppe_thres[i] = he_cap->ppe_thres[i];
 		}
@@ -1990,12 +1990,12 @@ int rwnx_send_me_sta_add(struct rwnx_hw *rwnx_hw, struct station_parameters *par
 
 
         req->flags |= STA_HT_CAPA;
-        req->ht_cap.ht_capa_info = cpu_to_le16(ht_capa->cap_info);
+        req->ht_cap.ht_capa_info = (__force u16_l)ht_capa->cap_info;
         req->ht_cap.a_mpdu_param = ht_capa->ampdu_params_info;
         for (i = 0; i < sizeof(ht_capa->mcs); i++)
             req->ht_cap.mcs_rate[i] = ht_mcs[i];
-        req->ht_cap.ht_extended_capa = cpu_to_le16(ht_capa->extended_ht_cap_info);
-        req->ht_cap.tx_beamforming_capa = cpu_to_le32(ht_capa->tx_BF_cap_info);
+        req->ht_cap.ht_extended_capa = (__force u16_l)ht_capa->extended_ht_cap_info;
+        req->ht_cap.tx_beamforming_capa = (__force u32_l)ht_capa->tx_BF_cap_info;
         req->ht_cap.asel_capa = ht_capa->antenna_selection_info;
     }
 
@@ -2008,22 +2008,22 @@ int rwnx_send_me_sta_add(struct rwnx_hw *rwnx_hw, struct station_parameters *par
 		const struct ieee80211_vht_cap *vht_capa = params->link_sta_params.vht_capa;
 #endif//LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
         req->flags |= STA_VHT_CAPA;
-        req->vht_cap.vht_capa_info = cpu_to_le32(vht_capa->vht_cap_info);
-        req->vht_cap.rx_highest = cpu_to_le16(vht_capa->supp_mcs.rx_highest);
-        req->vht_cap.rx_mcs_map = cpu_to_le16(vht_capa->supp_mcs.rx_mcs_map);
-        req->vht_cap.tx_highest = cpu_to_le16(vht_capa->supp_mcs.tx_highest);
-        req->vht_cap.tx_mcs_map = cpu_to_le16(vht_capa->supp_mcs.tx_mcs_map);
+        req->vht_cap.vht_capa_info = (__force u32_l)vht_capa->vht_cap_info;
+        req->vht_cap.rx_highest = (__force u16_l)vht_capa->supp_mcs.rx_highest;
+        req->vht_cap.rx_mcs_map = (__force u16_l)vht_capa->supp_mcs.rx_mcs_map;
+        req->vht_cap.tx_highest = (__force u16_l)vht_capa->supp_mcs.tx_highest;
+        req->vht_cap.tx_mcs_map = (__force u16_l)vht_capa->supp_mcs.tx_mcs_map;
     }
 #elif defined(CONFIG_VHT_FOR_OLD_KERNEL)
     if (sta->vht) {
         const struct ieee80211_vht_cap *vht_capa = rwnx_vht_capa;
 
         req->flags |= STA_VHT_CAPA;
-        req->vht_cap.vht_capa_info = cpu_to_le32(vht_capa->vht_cap_info);
-        req->vht_cap.rx_highest = cpu_to_le16(vht_capa->supp_mcs.rx_highest);
-        req->vht_cap.rx_mcs_map = cpu_to_le16(vht_capa->supp_mcs.rx_mcs_map);
-        req->vht_cap.tx_highest = cpu_to_le16(vht_capa->supp_mcs.tx_highest);
-        req->vht_cap.tx_mcs_map = cpu_to_le16(vht_capa->supp_mcs.tx_mcs_map);
+        req->vht_cap.vht_capa_info = (__force u32_l)vht_capa->vht_cap_info;
+        req->vht_cap.rx_highest = (__force u16_l)vht_capa->supp_mcs.rx_highest;
+        req->vht_cap.rx_mcs_map = (__force u16_l)vht_capa->supp_mcs.rx_mcs_map;
+        req->vht_cap.tx_highest = (__force u16_l)vht_capa->supp_mcs.tx_highest;
+        req->vht_cap.tx_mcs_map = (__force u16_l)vht_capa->supp_mcs.tx_mcs_map;
     }
 #endif
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
@@ -327,12 +327,10 @@ static void rwnx_rx_data_skb_resend(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rw
 {
 	struct sk_buff *rx_skb = skb;
 	//bool amsdu = rxhdr->flags_is_amsdu;
-	const struct ethhdr *eth;
 	struct sk_buff *skb_copy;
 
 	rx_skb->dev = rwnx_vif->ndev;
 	skb_reset_mac_header(rx_skb);
-	eth = eth_hdr(rx_skb);
 
     //printk("resend\n");
 	/* resend pkt on wireless interface */
@@ -1370,7 +1368,6 @@ static int reord_flush_tid(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u
     u8 found = 0;
     struct list_head *phead, *plist;
     struct recv_msdu *prframe;
-    int ret;
 
     if((rwnx_vif->wdev.iftype == NL80211_IFTYPE_STATION) || (rwnx_vif->wdev.iftype == NL80211_IFTYPE_P2P_CLIENT))
         mac = eh->h_dest;
@@ -1415,9 +1412,9 @@ static int reord_flush_tid(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u
     spin_unlock_irqrestore(&preorder_ctrl->reord_list_lock, flags);
     if (timer_pending(&preorder_ctrl->reord_timer))
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
-		ret = timer_delete_sync(&preorder_ctrl->reord_timer);
+		timer_delete_sync(&preorder_ctrl->reord_timer);
 #else
-        ret = del_timer_sync(&preorder_ctrl->reord_timer);
+        del_timer_sync(&preorder_ctrl->reord_timer);
 #endif
     cancel_work_sync(&preorder_ctrl->reord_timer_work);
 
@@ -1429,7 +1426,6 @@ void reord_deinit_sta(struct aicwf_rx_priv* rx_priv, struct reord_ctrl_info *reo
     u8 i = 0;
     //unsigned long flags;
     struct reord_ctrl *preorder_ctrl = NULL;
-    int ret;
 
     if (rx_priv == NULL) {
         txrx_err("bad rx_priv!\n");
@@ -1445,9 +1441,9 @@ void reord_deinit_sta(struct aicwf_rx_priv* rx_priv, struct reord_ctrl_info *reo
 			preorder_ctrl->enable = false;
 	        if (timer_pending(&preorder_ctrl->reord_timer)) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
-			    ret = timer_delete_sync(&preorder_ctrl->reord_timer);
+			    timer_delete_sync(&preorder_ctrl->reord_timer);
 #else
-	            ret = del_timer_sync(&preorder_ctrl->reord_timer);
+	            del_timer_sync(&preorder_ctrl->reord_timer);
 #endif
 	        }
 	        cancel_work_sync(&preorder_ctrl->reord_timer_work);
@@ -1998,7 +1994,7 @@ u8 rwnx_rxdataind_aicwf(struct rwnx_hw *rwnx_hw, void *hostid, void *rx_priv)
             skb->data += (msdu_offset + 2); //sdio/usb word allign
 
             //Save frame length
-            frm_len = le32_to_cpu(hw_rxhdr->hwvect.len);
+            frm_len = le32_to_cpu((__force __le32)hw_rxhdr->hwvect.len);
 
             // Reserve space for frame
             skb->len = frm_len;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_tx.c
@@ -1246,7 +1246,6 @@ netdev_tx_t rwnx_start_xmit(struct sk_buff *skb, struct net_device *dev)
     int hdr_pads;
 
     u16 frame_len;
-    u16 frame_oft;
     u8 tid;
     
     struct ethhdr eth_t;
@@ -1388,8 +1387,6 @@ netdev_tx_t rwnx_start_xmit(struct sk_buff *skb, struct net_device *dev)
     }
 
     /* Fill-in TX descriptor */
-    frame_oft = sizeof(struct rwnx_txhdr) - offsetof(struct rwnx_txhdr, hw_hdr)
-                + hdr_pads;// + sizeof(*eth);
  #if 0
 #ifdef CONFIG_RWNX_SPLIT_TX_BUF
     desc->host.packet_addr[0] = sw_txhdr->dma_addr + frame_oft;
@@ -1449,7 +1446,7 @@ int rwnx_start_mgmt_xmit(struct rwnx_vif *vif, struct rwnx_sta *sta,
     struct rwnx_sw_txhdr *sw_txhdr;
     struct txdesc_api *desc;
     struct sk_buff *skb;
-    u16 frame_len, headroom, frame_oft;
+    u16 frame_len, headroom;
     u8 *data;
     int nx_off_chan_txq_idx = NX_OFF_CHAN_TXQ_IDX;
     struct rwnx_txq *txq;
@@ -1603,7 +1600,6 @@ int rwnx_start_mgmt_xmit(struct rwnx_vif *vif, struct rwnx_sta *sta,
         return -EBUSY;
     }
 
-    frame_oft = sizeof(struct rwnx_txhdr) - offsetof(struct rwnx_txhdr, hw_hdr);
 	#if 0
 #ifdef CONFIG_RWNX_SPLIT_TX_BUF
     desc->host.packet_addr[0] = sw_txhdr->dma_addr + frame_oft;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_txq.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_txq.c
@@ -1226,12 +1226,10 @@ bool rwnx_txq_select_user(struct rwnx_hw *rwnx_hw, bool mu_lock,
  *
  * To be called with tx_lock hold
  */
-#define ALL_HWQ_MASK  ((1 << CONFIG_USER_MAX) - 1)
-
 void rwnx_hwq_process(struct rwnx_hw *rwnx_hw, struct rwnx_hwq *hwq)
 {
     struct rwnx_txq *txq, *next;
-    int user, credit_map = 0;
+    int user;
     bool mu_enable;
 #ifndef CONFIG_ONE_TXQ
     unsigned long flags;
@@ -1242,8 +1240,6 @@ void rwnx_hwq_process(struct rwnx_hw *rwnx_hw, struct rwnx_hwq *hwq)
     hwq->need_processing = false;
 
     mu_enable = rwnx_txq_take_mu_lock(rwnx_hw);
-    if (!mu_enable)
-        credit_map = ALL_HWQ_MASK - 1;
 
     list_for_each_entry_safe(txq, next, &hwq->list, sched_list) {
         struct rwnx_txhdr *txhdr = NULL;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_utils.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_utils.h
@@ -85,8 +85,6 @@ struct rwnx_ipc_dbgdump_elem {
     struct rwnx_ipc_elem_var buf;
 };
 
-static const u32 rwnx_rxbuff_pattern = 0xCAFEFADE;
-
 /*
  * Maximum Length of Radiotap header vendor specific data(in bytes)
  */

--- a/drivers/aic8800/aic_load_fw/aic_txrxif.c
+++ b/drivers/aic8800/aic_load_fw/aic_txrxif.c
@@ -161,13 +161,11 @@ void aicwf_tx_deinit(struct aicwf_tx_priv* tx_priv)
 
 static bool aicwf_another_ptk(struct sk_buff *skb)
 {
-    u8 *data;
     u16 aggr_len = 0;
 
     if(skb->data == NULL || skb->len == 0) {
         return false;
     }
-    data = skb->data;
     aggr_len = (*skb->data | (*(skb->data + 1) << 8));
     if(aggr_len == 0) {
         return false;

--- a/drivers/aic8800/aic_load_fw/aicwf_usb.c
+++ b/drivers/aic8800/aic_load_fw/aicwf_usb.c
@@ -270,7 +270,6 @@ static void aicwf_usb_tx_process(struct aic_usb_dev *usb_dev)
 {
     struct aicwf_usb_buf *usb_buf;
     int ret = 0;
-    u8* data = NULL;
 
     while(!list_empty(&usb_dev->tx_post_list)) {
         if (usb_dev->state != USB_UP_ST) {
@@ -284,7 +283,6 @@ static void aicwf_usb_tx_process(struct aic_usb_dev *usb_dev)
             usb_err("can not get usb_buf from tx_post_list!\n");
             return;
         }
-        data = usb_buf->skb->data;
 
         ret = usb_submit_urb(usb_buf->urb, GFP_ATOMIC);
         if (ret) {
@@ -536,12 +534,9 @@ err:
 
 static void aicwf_usb_state_change(struct aic_usb_dev *usb_dev, int state)
 {
-    int old_state;
-
     if (usb_dev->state == state)
         return;
 
-    old_state = usb_dev->state;
     usb_dev->state = state;
 
     if (state == USB_DOWN_ST) {


### PR DESCRIPTION
## What

~80 of the 231 sparse/gcc/cppcheck findings, and a root `permissions` block on all 7 workflows.

## Why

**Endianness (20 sites).** Capability fields read from `ieee80211_{ht,vht,he}_cap` are already little-endian. Wrapping them in `cpu_to_le16/32` swaps twice. Wrong on big-endian, invisible on x86, so codegen is unchanged for every target in the matrix.

Sparse separates the two cases and only the first was touched:

| Warning | Meaning |
| --- | --- |
| `cast from restricted __le*` | source already LE, double swap |
| `incorrect type in assignment` alone | correct code, `u16_l` field not typed `__le16` |

`rwnx_msg_tx.c:1781` and `:1793` read the parsed host-order `ieee80211_sta_*_cap` and are left as they are.

**Missing returns (3).** TDLS handlers in `rwnx_msg_rx.c` kept `return 0` inside `#ifdef CONFIG_RWNX_FULLMAC` and fell off the end without it. Always `y` here, so no behaviour change.

**Dead code.** 14 set-but-never-read variables, an unreferenced const in a header included by 23 TUs, 4 `NULL` comparisons written as `0`, one missing prototype. Two `ret =` assignments dropped without dropping the call, which has side effects.
