### PR TITLE
fix the teardown deadlock when the stick vanishes with wlan0 up

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -6636,6 +6636,14 @@ static void rwnx_wdev_unregister(struct rwnx_hw *rwnx_hw)
 
     rtnl_lock();
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+    /* Close every netdev before taking wiphy->mtx. cfg80211_unregister_wdev()
+     * unregisters a still-UP netdev from inside our locked section, and the
+     * cfg80211 netdev notifier takes wiphy->mtx itself for NETDEV_GOING_DOWN
+     * and NETDEV_DOWN - only NETDEV_UNREGISTER is guarded by wdev->registered.
+     * A surprise USB disconnect with wlan0 up therefore hangs hub_event in
+     * __mutex_lock forever. ieee80211_remove_interfaces() shuts its
+     * interfaces down the same way before its own wiphy lock. */
+    cfg80211_shutdown_all_interfaces(rwnx_hw->wiphy);
     /* cfg80211_unregister_wdev() (now called via rwnx_cfg80211_del_iface)
      * asserts wiphy->mtx held on 5.12+. The cfg80211 ops path holds it for
      * us; on this driver-internal teardown path (module unload / USB


### PR DESCRIPTION
## Problem

`rwnx_wdev_unregister()` holds `rtnl` **and** `wiphy->mtx` across `rwnx_cfg80211_del_iface()`, which unregisters the netdev via `cfg80211_unregister_wdev()`. If the interface is still up, `unregister_netdevice()` closes it first, and cfg80211s netdev notifier takes `wiphy->mtx` itself for `NETDEV_GOING_DOWN` (`scoped_guard(wiphy, ...)`) and `NETDEV_DOWN` (bare `wiphy_lock()`). Only `NETDEV_UNREGISTER` is short-circuited by `wdev->registered`, so the reasoning behind the patched.3 lock never covered the close path.

On a surprise USB disconnect with `wlan0` up, `hub_event` therefore blocks in `__mutex_lock` forever while holding rtnl, everything touching netlink queues up behind it, and the board looks frozen. Reported in #22 on a Raspberry Pi 1 running 6.18.39:

```
__mutex_lock.constprop.0 from cfg80211_netdev_notifier_call+0x25c/0x460 [cfg80211]
notifier_call_chain from raw_notifier_call_chain+0x20/0x28
raw_notifier_call_chain from __dev_close_many+0x64/0x218
__dev_close_many from netif_close_many+0x84/0x128
netif_close_many from unregister_netdevice_many_notify+0x220/0x9ac
unregister_netdevice_queue from _cfg80211_unregister_wdev+0x1e4/0x274 [cfg80211]
_cfg80211_unregister_wdev [cfg80211] from rwnx_cfg80211_del_iface+0x13c/0x17c [aic8800_fdrv]
rwnx_cfg80211_del_iface [aic8800_fdrv] from rwnx_cfg80211_deinit+0xac/0x170 [aic8800_fdrv]
aicwf_usb_disconnect [aic8800_fdrv] from usb_unbind_interface+0x7c/0x298
```

Latent since patched.3 (b90272e), which added the `wiphy_lock()` to fix the iwd-triggered deadlock on the nl80211 `del_interface` path. A clean `rmmod` or reboot never hits it because the supplicant brings `wlan0` down first.

## Why this shape

`ieee80211_remove_interfaces()` calls `cfg80211_shutdown_all_interfaces()` before its own `guard(wiphy)` for exactly this reason: that helper closes every netdev under rtnl only, so the notifier is free to take and release `wiphy->mtx`. `EXPORT_SYMBOL_GPL`, and this module is GPL.

Guarded to 5.12+, matching the existing `wiphy_lock()` block, so pre-wiphy-mutex kernels are untouched. All teardown callers (`aicwf_usb_disconnect`, `aicwf_usb_exit`, `rwnx_mod_exit`, the SDIO/PCI equivalents and the probe error paths) already have to enter without rtnl or `wiphy->mtx` held, since `rwnx_wdev_unregister()` takes both itself, so no caller contract changes. On the probe error paths the wdev list is empty and the call is a no-op.

## Status

Build-only verification here: the deadlock needs the reporters hardware to confirm the fix, and #22 asks them to test main. 6.18 is not in the CI matrix (6.12 LTS / 7.1 / latest / mainline -rc).