### PR TITLE
stop sleeping in the RX completion handler

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -284,18 +284,6 @@ static void aicwf_usb_rx_complete(struct urb *urb)
             aicwf_usb_rx_buf_put(usb_dev, usb_buf);
             if(urb->status < 0){
                 AICWFDBG(LOGDEBUG, "%s urb->status:%d \r\n", __func__, urb->status);
-    
-                if(g_rwnx_plat->wait_disconnect_cb == false){
-                    g_rwnx_plat->wait_disconnect_cb = true;
-                    if(atomic_read(&aicwf_deinit_atomic) > 0){
-                        atomic_set(&aicwf_deinit_atomic, 0);
-                        down(&aicwf_deinit_sem);
-                        AICWFDBG(LOGINFO, "%s need to wait for disconnect callback \r\n", __func__);
-                    }else{
-                        g_rwnx_plat->wait_disconnect_cb = false;
-                    }
-                }
-    
                 return;
             }else{
                 //schedule_work(&usb_dev->rx_urb_work);
@@ -367,18 +355,6 @@ static void aicwf_usb_rx_complete(struct urb *urb)
         aicwf_usb_rx_buf_put(usb_dev, usb_buf);
 		if(urb->status < 0){
 			AICWFDBG(LOGDEBUG, "%s urb->status:%d \r\n", __func__, urb->status);
-
-			if(g_rwnx_plat->wait_disconnect_cb == false){
-				g_rwnx_plat->wait_disconnect_cb = true;
-				if(atomic_read(&aicwf_deinit_atomic) > 0){
-					atomic_set(&aicwf_deinit_atomic, 0);
-					down(&aicwf_deinit_sem);
-					AICWFDBG(LOGINFO, "%s need to wait for disconnect callback \r\n", __func__);
-				}else{
-					g_rwnx_plat->wait_disconnect_cb = false;
-				}
-			}
-
 			return;
 		}else{
 			//schedule_work(&usb_dev->rx_urb_work);
@@ -1629,10 +1605,6 @@ static void aicwf_usb_bus_stop(struct device *dev)
     if (usb_dev->state == USB_DOWN_ST)
         return;
 
-    if(g_rwnx_plat->wait_disconnect_cb == true){
-            atomic_set(&aicwf_deinit_atomic, 1);
-            up(&aicwf_deinit_sem);
-    }
     aicwf_usb_state_change(usb_dev, USB_DOWN_ST);
     //aicwf_usb_cancel_all_urbs(usb_dev);//AIDEN
 }


### PR DESCRIPTION
`aicwf_usb_rx_complete()` calls `down(&aicwf_deinit_sem)` when `urb->status < 0`, in both of its variants. URB completion callbacks run in interrupt context and `down()` can sleep, so this is a scheduling-while-atomic bug that fires precisely on a surprise disconnect, since that errors every pending RX URB at once.

`aicwf_usb_bus_stop()` held the other half: an `up()` on the same semaphore that `aicwf_usb_disconnect()` is holding for the duration of teardown, so teardown released its own serialisation halfway through.

Removing the two handler blocks leaves `wait_disconnect_cb` permanently false, which is what makes the `down()`/`up()` pair in `aicwf_usb_disconnect()` behave as intended: taken once on entry, released once on exit, serialising against a re-probe. The field itself is left in place so this stays the same shape as the upstream fix.

radxa-pkg/aic8800 ships exactly this removal as `debian/patches/fix-usb-suspend-reboot-hang.patch`, having hit it on suspend and reboot rather than on unplug.

Related to #22, which is a different hang on the same path: that one is the wiphy mutex in the cfg80211 teardown, fixed in #23. Neither fix covers the other.