### PR TITLE
quiet the firmware patch dump and add a 6.18 build

### DIFF
--- a/.github/workflows/kernel-6.18.yml
+++ b/.github/workflows/kernel-6.18.yml
@@ -1,0 +1,18 @@
+name: 6.18
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-kernel.yml
+    with:
+      pkgver: 6.18.13.arch1-1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AIC8800DC Linux Driver (Patched)
 
 [![6.12 LTS](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-6.12-lts.yml/badge.svg)](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-6.12-lts.yml)
+[![6.18](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-6.18.yml/badge.svg)](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-6.18.yml)
 [![7.1 stable](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-7.1.yml/badge.svg)](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-7.1.yml)
 [![latest](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-latest.yml/badge.svg)](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-latest.yml)
 [![mainline rc](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-mainline-rc.yml/badge.svg)](https://github.com/Kiborgik/aic8800dc-linux-patched/actions/workflows/kernel-mainline-rc.yml)

--- a/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800dc.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800dc.c
@@ -1759,7 +1759,7 @@ int aicwf_patch_table_load(struct rwnx_hw *rwnx_hw, char *filename)
 
     if (!err && (i < size)) {
         for (i =(128/4); i < (size/4); i +=2) {
-            AICWFDBG(LOGERROR, "patch_tbl:  %x  %x\n", dst[i], dst[i+1]);
+            AICWFDBG(LOGDEBUG, "patch_tbl:  %x  %x\n", dst[i], dst[i+1]);
             err = rwnx_send_dbg_mem_write_req(rwnx_hw, dst[i], dst[i+1]);
         }
         if (err) {
@@ -1841,7 +1841,7 @@ void aicwf_patch_config_8800dc(struct rwnx_hw *rwnx_hw)
        AICWFDBG(LOGINFO, "wifisetting_cfg_addr=%x, ldpc_cfg_addr=%x, agc_cfg_addr=%x, txgain_cfg_addr=%x\n", wifisetting_cfg_addr, ldpc_cfg_addr, agc_cfg_addr, txgain_cfg_addr);
 
         for (cnt = 0; cnt < patch_tbl_wifisetting_num; cnt++) {
-            printk("patch %x = %x\n", wifisetting_cfg_addr + patch_tbl_wifisetting[cnt][0],
+            AICWFDBG(LOGDEBUG, "patch %x = %x\n", wifisetting_cfg_addr + patch_tbl_wifisetting[cnt][0],
                 patch_tbl_wifisetting[cnt][1]);
             if ((ret = rwnx_send_dbg_mem_write_req(rwnx_hw, wifisetting_cfg_addr + patch_tbl_wifisetting[cnt][0], patch_tbl_wifisetting[cnt][1]))) {
                 AICWFDBG(LOGERROR, "wifisetting %x write fail\n", patch_tbl_wifisetting[cnt][0]);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1780,7 +1780,7 @@ static int aicwf_parse_usb(struct aic_usb_dev *usb_dev, struct usb_interface *in
 				AICWFDBG(LOGERROR, "AIC8800DC change to AIC8800DW\n");
 				usb_dev->chipid = PRODUCT_ID_AIC8800DW;
 			}else if (usb_dev->chipid == PRODUCT_ID_AIC8800DW) {
-				printk("8800dw\n");
+				AICWFDBG(LOGERROR, "AIC8800DW\n");
 			}
 		}
     }


### PR DESCRIPTION
Two things, both fallout from #22.

**Boot log.** `rwnx_plat_patch_bin_upload_8800dc()` logs `patch_tbl: %x %x` at `LOGERROR` once per table entry, which is the forty-odd lines the reporter pasted, and the wifisetting loop below it uses a bare `printk` with no prefix or level. Both are routine firmware-patch progress, so they move to `LOGDEBUG`. The bare `printk("8800dw")` in `aicwf_parse_usb()` becomes an `AICWFDBG` line at its sibling level so it carries a prefix.

**CI matrix.** It went 6.12 LTS then straight to 7.1, so nothing built the 6.18 line the Raspberry Pi images ship, which is where #22 was reported. Added `kernel-6.18.yml` pinned to `6.18.13.arch1-1`, the highest 6.18 in the Arch archive, plus its badge.