### PR TITLE
kill the TX URBs that outlive a disconnect

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -901,8 +901,10 @@ static void aicwf_usb_tx_process(struct aic_usb_dev *usb_dev)
             return;
         }
 
+        usb_anchor_urb(usb_buf->urb, &usb_dev->tx_submitted);
         ret = usb_submit_urb(usb_buf->urb, GFP_ATOMIC);
         if (ret) {
+            usb_unanchor_urb(usb_buf->urb);
             AICWFDBG(LOGERROR, "aicwf_usb_bus_tx usb_submit_urb FAILED err:%d\n", ret);
             #ifdef CONFIG_USB_TX_AGGR
             aicwf_usb_tx_queue(usb_dev, &usb_dev->tx_post_list, usb_buf,
@@ -1156,21 +1158,29 @@ static void aicwf_usb_free_urb(struct list_head *q, spinlock_t *qlock)
 {
     struct aicwf_usb_buf *usb_buf, *tmp;
     unsigned long flags;
+    LIST_HEAD(to_free);
 
+    /* Take the whole list first: usb_free_urb() and the buffer frees below
+     * can sleep, so they cannot run under qlock, and the cursor of a
+     * list_for_each_entry_safe() is only valid while the lock is held. */
     spin_lock_irqsave(qlock, flags);
-    list_for_each_entry_safe(usb_buf, tmp, q, list) {
+    list_splice_init(q, &to_free);
     spin_unlock_irqrestore(qlock, flags);
+
+    list_for_each_entry_safe(usb_buf, tmp, &to_free, list) {
+        list_del_init(&usb_buf->list);
         if (!usb_buf->urb) {
             usb_err("bad usb_buf\n");
-            spin_lock_irqsave(qlock, flags);
-            break;
+            continue;
         }
         #ifdef CONFIG_USB_TX_AGGR
         if (usb_buf->skb) {
             dev_kfree_skb(usb_buf->skb);
+            usb_buf->skb = NULL;
         }
         #endif
         usb_free_urb(usb_buf->urb);
+        usb_buf->urb = NULL;
         #if defined CONFIG_USB_NO_TRANS_DMA_MAP
         // free dma buf if needed
         if (usb_buf->data_buf) {
@@ -1183,10 +1193,7 @@ static void aicwf_usb_free_urb(struct list_head *q, spinlock_t *qlock)
             usb_buf->data_dma_trans_addr = 0x0;
         }
         #endif
-        list_del_init(&usb_buf->list);
-        spin_lock_irqsave(qlock, flags);
     }
-    spin_unlock_irqrestore(qlock, flags);
 }
 
 static int aicwf_usb_alloc_rx_urb(struct aic_usb_dev *usb_dev)
@@ -1547,45 +1554,48 @@ static void aicwf_usb_cancel_all_urbs_(struct aic_usb_dev *usb_dev)
 {
     struct aicwf_usb_buf *usb_buf, *tmp;
     unsigned long flags;
+    LIST_HEAD(post_drain);
 
     if (usb_dev->msg_out_urb)
         usb_kill_urb(usb_dev->msg_out_urb);
 
-    spin_lock_irqsave(&usb_dev->tx_post_lock, flags);
-    list_for_each_entry_safe(usb_buf, tmp, &usb_dev->tx_post_list, list) {
-        spin_unlock_irqrestore(&usb_dev->tx_post_lock, flags);
-        if (!usb_buf->urb) {
-            usb_err("bad usb_buf\n");
-            spin_lock_irqsave(&usb_dev->tx_post_lock, flags);
-            break;
-        }
-        usb_kill_urb(usb_buf->urb);
-        #if defined CONFIG_USB_NO_TRANS_DMA_MAP
-        // free dma buf if needed
-        if (usb_buf->data_buf) {
-            #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
-            usb_free_coherent(usb_buf->usbdev->udev, DATA_BUF_MAX, usb_buf->data_buf, usb_buf->data_dma_trans_addr);
-            #else
-            usb_buffer_free(usb_buf->usbdev->udev, DATA_BUF_MAX, usb_buf->data_buf, usb_buf->data_dma_trans_addr);
-            #endif
-            usb_buf->data_buf = NULL;
-            usb_buf->data_dma_trans_addr = 0x0;
-        } else {
-            usb_err("bad usb dma buf\n");
-            spin_lock_irqsave(&usb_dev->tx_post_lock, flags);
-            break;
-        }
-        #endif
-        spin_lock_irqsave(&usb_dev->tx_post_lock, flags);
-    }
-    spin_unlock_irqrestore(&usb_dev->tx_post_lock, flags);
-
-    usb_kill_anchored_urbs(&usb_dev->rx_submitted);
+    /* Poison instead of kill: aicwf_usb_tx_process() can be past its
+     * USB_UP_ST check by the time we get here, and a poisoned anchor makes
+     * its submit fail instead of leaving a fresh URB in flight behind us. */
+    usb_poison_anchored_urbs(&usb_dev->tx_submitted);
+    usb_poison_anchored_urbs(&usb_dev->rx_submitted);
 #ifdef CONFIG_USB_MSG_IN_EP
 	if(usb_dev->chipid != PRODUCT_ID_AIC8801){
-   		usb_kill_anchored_urbs(&usb_dev->msg_rx_submitted);
+   		usb_poison_anchored_urbs(&usb_dev->msg_rx_submitted);
 	}
 #endif
+
+    /* Buffers queued for TX but never submitted. The state check in
+     * aicwf_usb_tx_process() stops the queue draining itself. */
+    spin_lock_irqsave(&usb_dev->tx_post_lock, flags);
+    list_splice_init(&usb_dev->tx_post_list, &post_drain);
+    usb_dev->tx_post_count = 0;
+    spin_unlock_irqrestore(&usb_dev->tx_post_lock, flags);
+
+    list_for_each_entry_safe(usb_buf, tmp, &post_drain, list) {
+        list_del_init(&usb_buf->list);
+        #ifndef CONFIG_USB_TX_AGGR
+        if (usb_buf->skb) {
+            /* Same ownership split as aicwf_usb_tx_complete(). */
+            if (usb_buf->cfm == false) {
+                dev_kfree_skb_any(usb_buf->skb);
+            }
+            #if !defined CONFIG_USB_NO_TRANS_DMA_MAP
+            else {
+                kfree((u8 *)usb_buf->skb);
+            }
+            #endif
+            usb_buf->skb = NULL;
+        }
+        #endif
+        aicwf_usb_tx_queue(usb_dev, &usb_dev->tx_free_list, usb_buf,
+                    &usb_dev->tx_free_count, &usb_dev->tx_free_lock);
+    }
 }
 
 void aicwf_usb_cancel_all_urbs(struct aic_usb_dev *usb_dev){
@@ -1621,6 +1631,10 @@ static void aicwf_usb_deinit(struct aic_usb_dev *usbdev)
 	}
 #endif
 
+    /* The kill in aicwf_usb_cancel_all_urbs_() leaves this URB reusable, and
+     * rwnx_cfg80211_deinit() still sends firmware messages after it, so it
+     * can be in flight again by now. */
+    usb_kill_urb(usbdev->msg_out_urb);
     usb_free_urb(usbdev->msg_out_urb);
 }
 
@@ -1649,6 +1663,7 @@ static int aicwf_usb_init(struct aic_usb_dev *usb_dev)
 
     init_waitqueue_head(&usb_dev->msg_wait);
     init_usb_anchor(&usb_dev->rx_submitted);
+    init_usb_anchor(&usb_dev->tx_submitted);
 #ifdef CONFIG_USB_MSG_IN_EP
 	if(usb_dev->chipid != PRODUCT_ID_AIC8801){
 		init_usb_anchor(&usb_dev->msg_rx_submitted);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.h
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.h
@@ -112,6 +112,7 @@ struct aic_usb_dev {
 #endif
 
     struct usb_anchor rx_submitted;
+    struct usb_anchor tx_submitted;
     struct work_struct rx_urb_work;
 #ifdef CONFIG_USB_MSG_IN_EP
 	struct usb_anchor msg_rx_submitted;

--- a/drivers/aic8800/aic_load_fw/aicwf_usb.c
+++ b/drivers/aic8800/aic_load_fw/aicwf_usb.c
@@ -284,8 +284,10 @@ static void aicwf_usb_tx_process(struct aic_usb_dev *usb_dev)
             return;
         }
 
+        usb_anchor_urb(usb_buf->urb, &usb_dev->tx_submitted);
         ret = usb_submit_urb(usb_buf->urb, GFP_ATOMIC);
         if (ret) {
+            usb_unanchor_urb(usb_buf->urb);
             usb_err("aicwf_usb_bus_tx usb_submit_urb FAILED\n");
             goto fail;
         }
@@ -460,20 +462,23 @@ static void aicwf_usb_free_urb(struct list_head *q, spinlock_t *qlock)
 {
     struct aicwf_usb_buf *usb_buf, *tmp;
     unsigned long flags;
+    LIST_HEAD(to_free);
 
+    /* usb_free_urb() can sleep, so it cannot run under qlock, and the cursor
+     * of a list_for_each_entry_safe() only survives while the lock is held. */
     spin_lock_irqsave(qlock, flags);
-    list_for_each_entry_safe(usb_buf, tmp, q, list) {
+    list_splice_init(q, &to_free);
     spin_unlock_irqrestore(qlock, flags);
+
+    list_for_each_entry_safe(usb_buf, tmp, &to_free, list) {
+        list_del_init(&usb_buf->list);
         if (!usb_buf->urb) {
             usb_err("bad usb_buf\n");
-            spin_lock_irqsave(qlock, flags);
-            break;
+            continue;
         }
         usb_free_urb(usb_buf->urb);
-        list_del_init(&usb_buf->list);
-        spin_lock_irqsave(qlock, flags);
+        usb_buf->urb = NULL;
     }
-    spin_unlock_irqrestore(qlock, flags);
 }
 
 static int aicwf_usb_alloc_rx_urb(struct aic_usb_dev *usb_dev)
@@ -618,25 +623,14 @@ static int aicwf_usb_bus_start(struct device *dev)
 
 static void aicwf_usb_cancel_all_urbs(struct aic_usb_dev *usb_dev)
 {
-    struct aicwf_usb_buf *usb_buf, *tmp;
-    unsigned long flags;
-
     if (usb_dev->msg_out_urb)
         usb_kill_urb(usb_dev->msg_out_urb);
 
-    spin_lock_irqsave(&usb_dev->tx_post_lock, flags);
-    list_for_each_entry_safe(usb_buf, tmp, &usb_dev->tx_post_list, list) {
-        spin_unlock_irqrestore(&usb_dev->tx_post_lock, flags);
-        if (!usb_buf->urb) {
-            usb_err("bad usb_buf\n");
-            spin_lock_irqsave(&usb_dev->tx_post_lock, flags);
-            break;
-        }
-        usb_kill_urb(usb_buf->urb);
-        spin_lock_irqsave(&usb_dev->tx_post_lock, flags);
-    }
-    spin_unlock_irqrestore(&usb_dev->tx_post_lock, flags);
-
+    /* Killing the tx_post_list did nothing: aicwf_usb_tx_dequeue() unlinks a
+     * buffer before it is submitted, so in-flight URBs were on no list at all
+     * and outlived the disconnect. Kill rather than poison, because this runs
+     * on the suspend path too and the anchor has to work again after resume. */
+    usb_kill_anchored_urbs(&usb_dev->tx_submitted);
     usb_kill_anchored_urbs(&usb_dev->rx_submitted);
 }
 
@@ -680,6 +674,7 @@ static int aicwf_usb_init(struct aic_usb_dev *usb_dev)
 
     init_waitqueue_head(&usb_dev->msg_wait);
     init_usb_anchor(&usb_dev->rx_submitted);
+    init_usb_anchor(&usb_dev->tx_submitted);
 
     spin_lock_init(&usb_dev->tx_free_lock);
     spin_lock_init(&usb_dev->tx_post_lock);

--- a/drivers/aic8800/aic_load_fw/aicwf_usb.h
+++ b/drivers/aic8800/aic_load_fw/aicwf_usb.h
@@ -114,6 +114,7 @@ struct aic_usb_dev {
     enum aicwf_usb_state state;
 
     struct usb_anchor rx_submitted;
+    struct usb_anchor tx_submitted;
     struct work_struct rx_urb_work;
 
     spinlock_t rx_free_lock;


### PR DESCRIPTION
`aicwf_usb_tx_dequeue()` unlinks a buffer before `aicwf_usb_tx_process()` submits it, so an in-flight TX URB is on no list at all. The teardown loop in `aicwf_usb_cancel_all_urbs_()` walked `tx_post_list`, which by construction holds only buffers that were never submitted, and `usb_kill_urb()` returns immediately for those because their `urb->ep` is NULL. RX and msg-RX had anchors, TX had nothing, so after a surprise unplug the real TX URBs completed into `aicwf_usb_tx_complete()`, which dereferences `usb_buf->usbdev` and touches `tx_free_list`, `tbusy` and `rwnx_hw` after `aicwf_usb_disconnect()` has run `kfree(usb_dev)`. Their URBs leaked too, since `aicwf_usb_deinit()` only frees what is on the free and post lists.

The kernel is explicit about the contract: "No I/O operations or actions that could interfere with other drivers are permitted after this callback returns. Outstanding URBs must be completed or aborted beforehand." (`Documentation/driver-api/usb/callbacks.rst`)

**What changed.** TX gets its own anchor, anchored immediately before submit and unanchored on the submit-failure branch only, since `__usb_hcd_giveback_urb()` unanchors before calling the completion handler. The hand-rolled `tx_post_list` kill loop becomes one anchor call, and the list is instead drained of never-submitted buffers with the same skb ownership split `aicwf_usb_tx_complete()` uses.

**Poison in the fullmac driver, kill in aic_load_fw**, deliberately. `aicwf_usb_tx_process()` can already be past its `USB_UP_ST` check when teardown starts, and `usb_poison_anchored_urbs()` makes the later submit fail because `usb_anchor_urb()` raises `urb->reject` on a poisoned anchor. In `aic_load_fw` the same cancel path also runs from `aicwf_usb_suspend()` via `aicwf_bus_stop()`, where poisoning would leave the anchor dead after resume, so that side kills.

**Also in here:** `aicwf_usb_free_urb()` held the queue lock across `usb_free_urb()`, which sleeps, and its `break` on a bad entry abandoned every entry behind it. It now splices under the lock and walks lock-free. And `msg_out_urb` is killed once more immediately before `usb_free_urb()`, because the kill during cancel leaves it reusable and `rwnx_cfg80211_deinit()` still sends firmware messages afterwards.