### PR TITLE
feat: Add support for AIC8800FC U2 USB ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ sudo ./uninstall.sh
 ## Troubleshooting
 
 **Driver loads but no `wlan0` appears.** The dongle is probably stuck in
-USB mass-storage mode (VID:PID `a69c:5721`). The udev rule in
-`tools/aic.rules` runs `eject` to flip it into Wi-Fi mode; if `eject`
-isn't installed or the dongle enumerates as a CD-ROM (`sr0` instead of
-`sd*`), nothing happens. Manual fix:
+USB mass-storage mode. AIC's own sticks show up as `a69c:5721`,
+`a69c:5722` or `a69c:572a` until they are ejected; `lsusb` tells you
+which. The udev rule in `tools/aic.rules` runs `eject` to flip them into
+Wi-Fi mode; if `eject` isn't installed or the dongle enumerates as a
+CD-ROM (`sr0` instead of `sd*`), nothing happens. Manual fix:
 
 ```bash
 sudo apt install usb-modeswitch
-sudo usb_modeswitch -v a69c -p 5721 -KQ
+sudo usb_modeswitch -v a69c -p 5721 -KQ   # use the PID lsusb showed
 # wait a few seconds, then:
 ip link show
 dmesg | tail -30

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1967,6 +1967,7 @@ static int aicwf_usb_chipmatch(struct aic_usb_dev *usb_dev, u16_l vid, u16_l pid
 		AICWFDBG(LOGINFO, "%s USE AIC8800DC\r\n", __func__);
 		return 0;
 	}else if(pid == USB_PRODUCT_ID_AIC8800DW
+	 || pid == USB_PRODUCT_ID_AIC8800FC_U2
 	 || pid == USB_PRODUCT_ID_AIC8800FC ||
         (vid == USB_VENDOR_ID_TP && pid == USB_PRODUCT_ID_TP)
         || (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2)){
@@ -2202,6 +2203,8 @@ static struct usb_device_id aicwf_usb_id_table[] = {
     {USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8801, 0xff, 0xff, 0xff)},
     {USB_DEVICE_AND_INTERFACE_INFO(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800DC, 0xff, 0xff, 0xff)},
     {USB_DEVICE(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800DW)},
+    {USB_DEVICE(USB_VENDOR_ID_AIC, USB_PRODUCT_ID_AIC8800FC_U2)},
+    {USB_DEVICE(USB_VENDOR_ID_AIC_V2, USB_PRODUCT_ID_AIC8800FC_U2)},
     {USB_DEVICE(USB_VENDOR_ID_AIC_V2, USB_PRODUCT_ID_AIC8800FC)},
     {USB_DEVICE(USB_VENDOR_ID_TENDA, USB_PRODUCT_ID_TENDA)},
     /* Tenda U2 (2604:0014) is untested: it has no entry in aicwf_usb_chipmatch()

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.h
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.h
@@ -28,6 +28,7 @@
 #define USB_PRODUCT_ID_AIC8801				0x8801
 #define USB_PRODUCT_ID_AIC8800DC			0x88dc
 #define USB_PRODUCT_ID_AIC8800DW            0x88dd
+#define USB_PRODUCT_ID_AIC8800FC_U2         0x88de
 #define USB_PRODUCT_ID_AIC8800FC            0x88df
 #define USB_PRODUCT_ID_TENDA                0x0013
 #define USB_PRODUCT_ID_TENDA_U2             0x0014

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ fi
 
 # Check dependencies. `eject` is needed by tools/aic.rules to flip dongles
 # out of USB mass-storage mode on first plug; without it the device stays
-# at VID:PID a69c:5721 and the Wi-Fi PID never appears.
+# at VID:PID a69c:5721, a69c:5722 or a69c:572a and the Wi-Fi PID never appears.
 for cmd in dkms make depmod eject; do
     if ! command -v "$cmd" &>/dev/null; then
         echo "Error: '$cmd' is not installed." >&2
@@ -58,9 +58,12 @@ cp "${SCRIPT_DIR}/tools/aic.rules" /etc/udev/rules.d/
 # other way round fires the trigger with stale rules.
 udevadm control --reload
 udevadm trigger
-if [ -L /dev/aicudisk ]; then
-    eject /dev/aicudisk || true
-fi
+# trigger only queues the events; without settle the symlink is not there yet
+udevadm settle || true
+for node in /dev/aicudisk*; do
+    [ -e "$node" ] || continue
+    eject "$node" || true
+done
 
 # --- Prepare DKMS source tree ---
 # Remove every previously registered version (not just the same version)

--- a/tools/aic.rules
+++ b/tools/aic.rules
@@ -1,2 +1,3 @@
 KERNEL=="sd*", ATTRS{idVendor}=="a69c", ATTRS{idProduct}=="5721",  SYMLINK+="aicudisk", RUN+="/usr/bin/eject /dev/%k"
-KERNEL=="sd*", ATTRS{idVendor}=="a69c", ATTRS{idProduct}=="5722", SYMLINK+="aicudiskv2", RUN+="/usr/bin/eject /dev/%k"
+KERNEL=="sd*", ATTRS{idVendor}=="a69c", ATTRS{idProduct}=="5722",  SYMLINK+="aicudiskv2", RUN+="/usr/bin/eject /dev/%k"
+KERNEL=="sd*", ATTRS{idVendor}=="a69c", ATTRS{idProduct}=="572a",  SYMLINK+="aicudiskv3", RUN+="/usr/bin/eject /dev/%k"

--- a/tools/aic.rules
+++ b/tools/aic.rules
@@ -1,1 +1,2 @@
 KERNEL=="sd*", ATTRS{idVendor}=="a69c", ATTRS{idProduct}=="5721",  SYMLINK+="aicudisk", RUN+="/usr/bin/eject /dev/%k"
+KERNEL=="sd*", ATTRS{idVendor}=="a69c", ATTRS{idProduct}=="5722", SYMLINK+="aicudiskv2", RUN+="/usr/bin/eject /dev/%k"


### PR DESCRIPTION
This pull request adds support for a new USB device variant, `AIC8800FC_U2`, to the AIC8800 USB driver. The main changes include defining the new product ID, updating device matching logic, and registering the device in the USB ID table.

**Device support updates:**

* Defined `USB_PRODUCT_ID_AIC8800FC_U2` with value `0x88de` in `aicwf_usb.h`.
* Added `USB_PRODUCT_ID_AIC8800FC_U2` to the device matching logic in `aicwf_usb_chipmatch` in `aicwf_usb.c`.
* Registered the new device in the `aicwf_usb_id_table` array in `aicwf_usb.c`.