### PR TITLE
Fix TP-Link AX300 (3625:0110) chip misclassification and false interface-count error

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1782,22 +1782,15 @@ static int aicwf_parse_usb(struct aic_usb_dev *usb_dev, struct usb_interface *in
 #else
     if (usb->actconfig->desc.bNumInterfaces != 1) {
 #endif
-		/* The MA14N has no Bluetooth, so it shows one interface where a
-		   BT build expects three. Normal for this stick, and the DC
-		   chipid from its VID/PID has to survive. */
-		if (le16_to_cpu(usb->descriptor.idVendor) == USB_VENDOR_ID_MERCUSYS &&
-		    le16_to_cpu(usb->descriptor.idProduct) == USB_PRODUCT_ID_MERCUSYS) {
-			AICWFDBG(LOGINFO, "Mercusys MA14N: single interface, keeping AIC8800DC\n");
-		} else {
-			AICWFDBG(LOGERROR, "Number of interfaces: %d not supported\n",
-				usb->actconfig->desc.bNumInterfaces);
-			if(usb_dev->chipid == PRODUCT_ID_AIC8800DC){
-				AICWFDBG(LOGERROR, "AIC8800DC change to AIC8800DW\n");
-				usb_dev->chipid = PRODUCT_ID_AIC8800DW;
-			}else if (usb_dev->chipid == PRODUCT_ID_AIC8800DW) {
-				AICWFDBG(LOGERROR, "AIC8800DW\n");
-			}
-		}
+		/* WiFi-only sticks (no onboard Bluetooth) enumerate with a single
+		   vendor interface even on a CONFIG_USB_BT build, which normally
+		   expects three (WiFi + BT ACL + BT SCO). chipid is decided by
+		   aicwf_usb_chipmatch()'s VID/PID match, and firmware/calibration
+		   filenames are picked straight off the USB descriptor elsewhere
+		   in this driver, so interface count past this point doesn't
+		   gate anything and isn't evidence of DC vs DW either way. */
+		AICWFDBG(LOGINFO, "Number of interfaces: %d\n",
+			usb->actconfig->desc.bNumInterfaces);
     }
 
     if ((interface_desc->bInterfaceClass != USB_CLASS_VENDOR_SPEC) ||
@@ -1962,15 +1955,18 @@ static int aicwf_usb_chipmatch(struct aic_usb_dev *usb_dev, u16_l vid, u16_l pid
 	}else if(pid == USB_PRODUCT_ID_AIC8800DC ||
         (vid == USB_VENDOR_ID_TENDA && pid == USB_PRODUCT_ID_TENDA)
         /* MA14N reports itself as AIC8800DC; it sat in the DW branch below */
-        || (vid == USB_VENDOR_ID_MERCUSYS && pid == USB_PRODUCT_ID_MERCUSYS)){
+        || (vid == USB_VENDOR_ID_MERCUSYS && pid == USB_PRODUCT_ID_MERCUSYS)
+        /* TP-Link AX300 (Archer TX1U Nano): `lsusb -v -d 3625:0110` shows
+           iProduct "AIC8800DC" on the device itself, same signal used for
+           MA14N above; it sat in the DW branch below */
+        || (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2)){
 		usb_dev->chipid = PRODUCT_ID_AIC8800DC;
 		AICWFDBG(LOGINFO, "%s USE AIC8800DC\r\n", __func__);
 		return 0;
 	}else if(pid == USB_PRODUCT_ID_AIC8800DW
 	 || pid == USB_PRODUCT_ID_AIC8800FC_U2
 	 || pid == USB_PRODUCT_ID_AIC8800FC ||
-        (vid == USB_VENDOR_ID_TP && pid == USB_PRODUCT_ID_TP)
-        || (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2)){
+        (vid == USB_VENDOR_ID_TP && pid == USB_PRODUCT_ID_TP)){
         usb_dev->chipid = PRODUCT_ID_AIC8800DW;
 		AICWFDBG(LOGINFO, "%s USE AIC8800DW\r\n", __func__);
         return 0;


### PR DESCRIPTION
Updated per review feedback below (thanks for the detailed writeup -- addressing each point).

## What this actually fixes

Not calibration loading -- that was already working. `rwnx_plat_userconfig_load_8800dc()` and `rwnx_plat_patch_load()` key off the USB VID/PID descriptor directly, not off `chipid`, so `aic_userconfig_8800dc_3625.txt` was loading before this patch too.

What this fixes:

1. **`aicwf_usb_chipmatch()` misclassification**: TP2 (3625:0110) sat in the DW branch. `lsusb -v -d 3625:0110` shows `iProduct "AIC8800DC"` on the device itself -- same signal already used for the MA14N in #9/#20 -- so it belongs in the DC branch on that basis, not on interface count.
2. **False error log**: WiFi-only sticks hit `LOGERROR "Number of interfaces: 1 not supported"` and a DC->DW chipid flip on every plug-in, even though `aicwf_parse_usb()` continues with `ret 0` regardless and nothing downstream reads chipid differently. Per your point about the VID/PID list growing one stick at a time, I dropped the allowlist entirely and collapsed the whole branch into a single `LOGINFO` line -- covers 2357:0147 and the UGREEN 88de too, not just TP2/MA14N.

## Requested evidence

`lsusb -v -d 3625:0110`:
```
idVendor           0x3625 AICSemi
idProduct          0x0110 AIC8800DC
iManufacturer           1 AICSemi
iProduct                2 AIC8800DC
  bNumInterfaces          1
    bInterfaceNumber        0
    bInterfaceClass       255 Vendor Specific Class
```

With `aicwf_dbg_level=7` after this patch:
```
AICWFDBG(LOGINFO) aicwf_usb_chipmatch USE AIC8800DC
AICWFDBG(LOGINFO) Number of interfaces: 1
```
No LOGERROR lines, no DC->DW flip (previously: `LOGERROR Number of interfaces: 1 not supported` / `LOGERROR AIC8800DC change to AIC8800DW`).

`iw dev ... link` / `station dump`: no AP currently in range at my desk to associate with (this is the same range-limited setup from the original PR description), so I don't have this data point right now. Not blocking on my end if you'd rather merge without it.

## On your two open questions

- Kept this as the classification change (point 1) plus the collapsed-block fix (point 2) together in this PR, rather than splitting -- both are small and touch the same two spots in the same file, let me know if you'd rather I split them.
- Reworded the summary/commit message to drop the calibration-file claim and the "not supported" test-plan framing per your notes.

Full corrected commit message has the detail: see the updated commit.
