### PR TITLE
bind Tenda U2 (2604:0014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ For Rockchip / Allwinner / Amlogic, set the platform variables in
 ## Build for another kernel without rebooting
 
 ```bash
-sudo dkms build -m aic8800dc -v 6.4.3.0-patched.12 -k <other-version>
+sudo dkms build -m aic8800dc -v 6.4.3.0-patched.13 -k <other-version>
 dkms status
 ```

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.12"
+PACKAGE_VERSION="6.4.3.0-patched.13"
 
 BUILT_MODULE_NAME[0]="aic_load_fw"
 BUILT_MODULE_LOCATION[0]="drivers/aic8800/aic_load_fw/"

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1947,6 +1947,7 @@ static int aicwf_usb_chipmatch(struct aic_usb_dev *usb_dev, u16_l vid, u16_l pid
 		return 0;
 	}else if(pid == USB_PRODUCT_ID_AIC8800DC ||
         (vid == USB_VENDOR_ID_TENDA && pid == USB_PRODUCT_ID_TENDA)
+        || (vid == USB_VENDOR_ID_TENDA && pid == USB_PRODUCT_ID_TENDA_U2)
         /* MA14N reports itself as AIC8800DC; it sat in the DW branch below */
         || (vid == USB_VENDOR_ID_MERCUSYS && pid == USB_PRODUCT_ID_MERCUSYS)
         || (vid == USB_VENDOR_ID_TP2 && pid == USB_PRODUCT_ID_TP2)){
@@ -2193,9 +2194,7 @@ static struct usb_device_id aicwf_usb_id_table[] = {
     {USB_DEVICE(USB_VENDOR_ID_AIC_V2, USB_PRODUCT_ID_AIC8800FC_U2)},
     {USB_DEVICE(USB_VENDOR_ID_AIC_V2, USB_PRODUCT_ID_AIC8800FC)},
     {USB_DEVICE(USB_VENDOR_ID_TENDA, USB_PRODUCT_ID_TENDA)},
-    /* Tenda U2 (2604:0014) is untested: it has no entry in aicwf_usb_chipmatch()
-       and no RF calibration file, so binding it would only fail probe. */
-    //{USB_DEVICE(USB_VENDOR_ID_TENDA, USB_PRODUCT_ID_TENDA_U2)},
+    {USB_DEVICE(USB_VENDOR_ID_TENDA, USB_PRODUCT_ID_TENDA_U2)},
     {USB_DEVICE(USB_VENDOR_ID_TP, USB_PRODUCT_ID_TP)},
     {USB_DEVICE(USB_VENDOR_ID_TP2, USB_PRODUCT_ID_TP2)},
     {USB_DEVICE(USB_VENDOR_ID_MERCUSYS, USB_PRODUCT_ID_MERCUSYS)},

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -eu
 
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.12"
+PACKAGE_VERSION="6.4.3.0-patched.13"
 SRC_DIR="/usr/src/${PACKAGE_NAME}-${PACKAGE_VERSION}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PACKAGE_NAME="aic8800dc"
-PACKAGE_VERSION="6.4.3.0-patched.12"
+PACKAGE_VERSION="6.4.3.0-patched.13"
 KVER="$(uname -r)"
 PASS=0
 FAIL=0


### PR DESCRIPTION
Reported working in #30 once the commented-out table entry comes back.

DC arm on VID+PID, which is where Tenda's own driver puts 2604:0014 as well. No userconfig entry, because Tenda ships an aic_userconfig_8800dw_u2.txt whose power levels are value for value the same as the generic aic_userconfig_8800dc.txt already in the tree, so a 2604_0014 file would just be a copy of the fallback.

Closes #30.