### PR TITLE
fix: tolerate transient sta lookup miss in rwnx_cfg80211_add_key (fast re-association)

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -3533,6 +3533,26 @@ static int rwnx_cfg80211_add_key(struct wiphy *wiphy,
 
     if (mac_addr) {
         sta = rwnx_get_sta(rwnx_hw, mac_addr);
+        /*
+         * Fast re-association race: after the AP sends a deauth the 4-way
+         * handshake restarts as soon as the firmware's CONNECT_IND arrives,
+         * but the station is only inserted into sta_table by that same
+         * report.  On USB the EAPOL goes over the data endpoint while
+         * CONNECT_IND comes on the message endpoint, so the two are handled
+         * by different BH/RX threads and wpa_supplicant can install the PTK
+         * a moment before the station entry exists.  A hard -EINVAL there
+         * makes wpa_supplicant report a wrong PSK even though the password
+         * is correct.  In STA / P2P_CLIENT mode wait a little for the
+         * connect report to land (bounded, happy path sleeps zero).
+         */
+        if (!sta &&
+            (vif->wdev.iftype == NL80211_IFTYPE_STATION ||
+             vif->wdev.iftype == NL80211_IFTYPE_P2P_CLIENT)) {
+            for (i = 0; !sta && i < 10; i++) {
+                msleep(10);
+                sta = rwnx_get_sta(rwnx_hw, mac_addr);
+            }
+        }
         if (!sta)
             return -EINVAL;
         rwnx_key = &sta->key;


### PR DESCRIPTION
## Problem

On a station (STA) connection the AP occasionally sends a deauth (IEEE reason 7, "Class-3 frame from non-associated STA"). The client then does a **fast re-association back to the same AP**, and the 4-way handshake restarts immediately.

`wpa_supplicant` installs the PTK as soon as the firmware's `CONNECT_IND` arrives. But the host-side `rwnx_handle_connect_ind()` only inserts the station into `sta_table` *from that same report*. On this USB transport the EAPOL goes over the **data endpoint** while `CONNECT_IND` arrives on the **message endpoint**, so the two are handled by different RX threads (`aicwf_txrxif.c`, `CONFIG_USB_MSG_IN_EP=y`). There is therefore a real window where `rwnx_cfg80211_add_key()` calls `rwnx_get_sta()` and finds no entry, hits the hard `return -EINVAL`, and the kernel answers "nl80211: kernel reports: key not allowed".

`wpa_supplicant` misreads that as a wrong PSK:

```
CTRL-EVENT-SSID-TEMP-DISABLED reason=WRONG_KEY
```

even though the password is correct. The SSID is temp-disabled, the link stays down, and on desktop NetworkManager additionally enters `need-auth` and demands a manual password confirmation — turning a driver race into what looks like a credential failure. In my setup this kept the link down ~16h (no auto-reconnect) until someone intervened.

## Fix

In `rwnx_cfg80211_add_key()`, for a STA/P2P_CLIENT vif only: when the `sta_table` lookup misses, retry it in short bounded steps (up to 10 × 10 ms ≈ 100 ms) so the `CONNECT_IND` handler has time to insert the station. The original `-EINVAL` is preserved as the final failure path; the happy path (station already present) sleeps zero microseconds.

Deliberately not done here, to keep this PR minimal and safe:
- No "fallback" guessing of a `sta_idx` from a vif-side pointer — an unchecked fallback can target a stale/reused station slot. The lookup's `valid` + MAC match is the only authority.
- The applied retry is restricted to STA/P2P_CLIENT; AP/GO key installs for (possibly departed) clients keep the old behavior.
- The loop counter reuses the function's existing `int i` so the diff stays compatible with the repo's documented 3.10 (GNU89) floor.

## Notes

- `msleep()` is fine here: cfg80211 key-set handlers run in process context holding the wiphy mutex (and this driver never grabs `cb_lock` in this path).
- The same transient-miss pattern exists in `rwnx_cfg80211_del_key`; it has different failure semantics (a delete should be tolerant of a missing station) and is better fixed as part of a station-lifecycle/key-ownership clean-up than stuffed into this handshake fix. Happy to extend if preferred.
- Tested on Ubuntu 24.04, kernel 6.17, TP-Link AIC8800DC (USB `2357:0147`) against an RT-AC68U-style AP; fast reassociation now completes and no `WRONG_KEY` event fires.